### PR TITLE
Do not error even if predicate does not exist

### DIFF
--- a/ahnlich/db/src/engine/predicate.rs
+++ b/ahnlich/db/src/engine/predicate.rs
@@ -173,15 +173,10 @@ impl PredicateIndices {
         match condition {
             PredicateCondition::Value(main_predicate) => {
                 let predicate_values = self.inner.pin();
-                let pinned_keys = self.allowed_predicates.pin();
                 let key = main_predicate.get_key();
                 if let Some(predicate) = predicate_values.get(key) {
                     // retrieve the precise predicate if it exists and check against it
                     return Ok(predicate.matches(main_predicate));
-                } else if pinned_keys.contains(key) {
-                    // predicate does not exist because perhaps we have not been passing a value
-                    // but it is within allowed so this isn't an error
-                    return Ok(StdHashSet::new());
                 }
                 store.get_match_without_predicate(main_predicate)
             }

--- a/ahnlich/db/src/engine/predicate.rs
+++ b/ahnlich/db/src/engine/predicate.rs
@@ -1,4 +1,5 @@
 use super::super::errors::ServerError;
+use super::store::Store;
 use super::store::StoreKeyId;
 use ahnlich_types::keyval::StoreValue;
 use ahnlich_types::metadata::MetadataKey;
@@ -166,6 +167,8 @@ impl PredicateIndices {
     pub(super) fn matches(
         &self,
         condition: &PredicateCondition,
+        // used to check original store for things that do not have predicate
+        store: &Store,
     ) -> Result<StdHashSet<StoreKeyId>, ServerError> {
         match condition {
             PredicateCondition::Value(main_predicate) => {
@@ -180,17 +183,17 @@ impl PredicateIndices {
                     // but it is within allowed so this isn't an error
                     return Ok(StdHashSet::new());
                 }
-                Err(ServerError::PredicateNotFound(key.clone()))
+                store.get_match_without_predicate(main_predicate)
             }
             PredicateCondition::And(first, second) => {
-                let first_result = self.matches(first)?;
-                let second_result = self.matches(second)?;
+                let first_result = self.matches(first, store)?;
+                let second_result = self.matches(second, store)?;
                 // Get intersection of both conditions
                 Ok(first_result.intersection(&second_result).cloned().collect())
             }
             PredicateCondition::Or(first, second) => {
-                let first_result = self.matches(first)?;
-                let second_result = self.matches(second)?;
+                let first_result = self.matches(first, store)?;
+                let second_result = self.matches(second, store)?;
                 // Get union of both conditions
                 Ok(first_result.union(&second_result).cloned().collect())
             }
@@ -292,6 +295,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap as StdHashMap;
+    use std::num::NonZeroUsize;
     use std::sync::Arc;
 
     fn store_value_0() -> StoreValue {
@@ -392,12 +396,15 @@ mod tests {
     #[test]
     fn test_add_index_to_predicate_after() {
         let shared_pred = create_shared_predicate_indices(vec![MetadataKey::new("country".into())]);
-        let result = shared_pred.matches(&PredicateCondition::Value(Predicate::Equals {
-            key: MetadataKey::new("name".into()),
-            value: MetadataValue::RawString("David".into()),
-        }));
-        // We expect to be an error as we didn't index name
-        assert!(result.is_err());
+        let result = shared_pred.matches(
+            &PredicateCondition::Value(Predicate::Equals {
+                key: MetadataKey::new("name".into()),
+                value: MetadataValue::RawString("David".into()),
+            }),
+            &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+        );
+        // We don't have an index but it should use original store and return empty
+        assert!(result.unwrap().is_empty());
         shared_pred.add_predicates(
             vec![
                 MetadataKey::new("country".into()),
@@ -410,10 +417,13 @@ mod tests {
             ]),
         );
         let result = shared_pred
-            .matches(&PredicateCondition::Value(Predicate::Equals {
-                key: MetadataKey::new("name".into()),
-                value: MetadataValue::RawString("David".into()),
-            }))
+            .matches(
+                &PredicateCondition::Value(Predicate::Equals {
+                    key: MetadataKey::new("name".into()),
+                    value: MetadataValue::RawString("David".into()),
+                }),
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
             .unwrap();
         // Now we expect index to be up to date
         assert_eq!(result, StdHashSet::from_iter(["0".into(), "1".into()]),);
@@ -428,26 +438,35 @@ mod tests {
             MetadataKey::new("age".into()),
         ]);
         let result = shared_pred
-            .matches(&PredicateCondition::Value(Predicate::NotEquals {
-                key: MetadataKey::new("age".into()),
-                value: MetadataValue::RawString("14".into()),
-            }))
+            .matches(
+                &PredicateCondition::Value(Predicate::NotEquals {
+                    key: MetadataKey::new("age".into()),
+                    value: MetadataValue::RawString("14".into()),
+                }),
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
             .unwrap();
         // There are no entries where age is 14
         assert!(result.is_empty());
         let result = shared_pred
-            .matches(&PredicateCondition::Value(Predicate::NotEquals {
-                key: MetadataKey::new("country".into()),
-                value: MetadataValue::RawString("Nigeria".into()),
-            }))
+            .matches(
+                &PredicateCondition::Value(Predicate::NotEquals {
+                    key: MetadataKey::new("country".into()),
+                    value: MetadataValue::RawString("Nigeria".into()),
+                }),
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
             .unwrap();
         // only person 1 is not from Nigeria
         assert_eq!(result, StdHashSet::from_iter(["1".into()]));
         let result = shared_pred
-            .matches(&PredicateCondition::Value(Predicate::Equals {
-                key: MetadataKey::new("country".into()),
-                value: MetadataValue::RawString("Nigeria".into()),
-            }))
+            .matches(
+                &PredicateCondition::Value(Predicate::Equals {
+                    key: MetadataKey::new("country".into()),
+                    value: MetadataValue::RawString("Nigeria".into()),
+                }),
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
             .unwrap();
         assert_eq!(result, StdHashSet::from_iter(["0".into(), "2".into()]),);
         let check = PredicateCondition::Value(Predicate::Equals {
@@ -458,7 +477,12 @@ mod tests {
             key: MetadataKey::new("age".into()),
             value: MetadataValue::RawString("14".into()),
         }));
-        let result = shared_pred.matches(&check).unwrap();
+        let result = shared_pred
+            .matches(
+                &check,
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
+            .unwrap();
         // only person 1 is from Washington
         assert_eq!(result, StdHashSet::from_iter(["1".into()]));
         let check = PredicateCondition::Value(Predicate::Equals {
@@ -469,7 +493,12 @@ mod tests {
             key: MetadataKey::new("state".into()),
             value: MetadataValue::RawString("Plateau".into()),
         }));
-        let result = shared_pred.matches(&check).unwrap();
+        let result = shared_pred
+            .matches(
+                &check,
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
+            .unwrap();
         // only person 1 is fulfills all
         assert_eq!(result, StdHashSet::from_iter(["2".into()]));
         let check = PredicateCondition::Value(Predicate::Equals {
@@ -480,7 +509,12 @@ mod tests {
             key: MetadataKey::new("name".into()),
             value: MetadataValue::RawString("Diretnan".into()),
         }));
-        let result = shared_pred.matches(&check).unwrap();
+        let result = shared_pred
+            .matches(
+                &check,
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
+            .unwrap();
         // all 3 fulfill this
         assert_eq!(
             result,
@@ -490,24 +524,37 @@ mod tests {
             key: MetadataKey::new("country".into()),
             value: MetadataValue::RawString("USA".into()),
         }));
-        let result = shared_pred.matches(&check).unwrap();
+        let result = shared_pred
+            .matches(
+                &check,
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
+            .unwrap();
         // only person 1 is from Washington with any of those names
         assert_eq!(result, StdHashSet::from_iter(["1".into()]));
         // remove all Nigerians from the predicate and check that conditions working before no
         // longer work and those working before still work
         shared_pred.remove_store_keys(&["0".into(), "2".into()]);
         let result = shared_pred
-            .matches(&PredicateCondition::Value(Predicate::Equals {
-                key: MetadataKey::new("country".into()),
-                value: MetadataValue::RawString("Nigeria".into()),
-            }))
+            .matches(
+                &PredicateCondition::Value(Predicate::Equals {
+                    key: MetadataKey::new("country".into()),
+                    value: MetadataValue::RawString("Nigeria".into()),
+                }),
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
             .unwrap();
         assert!(result.is_empty());
         let check = check.and(PredicateCondition::Value(Predicate::Equals {
             key: MetadataKey::new("country".into()),
             value: MetadataValue::RawString("USA".into()),
         }));
-        let result = shared_pred.matches(&check).unwrap();
+        let result = shared_pred
+            .matches(
+                &check,
+                &Store::create(NonZeroUsize::new(1).unwrap(), vec![]),
+            )
+            .unwrap();
         // only person 1 is from Washington with any of those names
         assert_eq!(result, StdHashSet::from_iter(["1".into()]));
     }

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -6,6 +6,7 @@ use ahnlich_types::keyval::StoreKey;
 use ahnlich_types::keyval::StoreName;
 use ahnlich_types::keyval::StoreValue;
 use ahnlich_types::metadata::MetadataKey;
+use ahnlich_types::predicate::Predicate;
 use ahnlich_types::predicate::PredicateCondition;
 use ahnlich_types::server::StoreInfo;
 use ahnlich_types::server::StoreUpsert;
@@ -325,7 +326,7 @@ pub(crate) struct Store {
 
 impl Store {
     /// Creates a new empty store
-    fn create(dimension: NonZeroUsize, predicates: Vec<MetadataKey>) -> Self {
+    pub(super) fn create(dimension: NonZeroUsize, predicates: Vec<MetadataKey>) -> Self {
         Self {
             dimension,
             id_to_value: ConcurrentHashMap::new(),
@@ -384,7 +385,7 @@ impl Store {
     /// Deletes a bunch of store keys from the store matching a specific predicate
     #[tracing::instrument(skip(self))]
     fn delete_matches(&self, condition: &PredicateCondition) -> Result<usize, ServerError> {
-        let matches = self.predicate_indices.matches(condition)?.into_iter();
+        let matches = self.predicate_indices.matches(condition, self)?.into_iter();
         Ok(self.delete(matches))
     }
 
@@ -405,8 +406,54 @@ impl Store {
         &self,
         condition: &PredicateCondition,
     ) -> Result<Vec<(StoreKey, StoreValue)>, ServerError> {
-        let matches = self.predicate_indices.matches(condition)?.into_iter();
+        let matches = self.predicate_indices.matches(condition, self)?.into_iter();
         Ok(self.get(matches))
+    }
+
+    /// Used whenever there is no found predicate and so we search directly within store
+    #[tracing::instrument(skip(self))]
+    pub(super) fn get_match_without_predicate(
+        &self,
+        predicate: &Predicate,
+    ) -> Result<StdHashSet<StoreKeyId>, ServerError> {
+        let store_val_pinned = self.id_to_value.pin();
+        let res = match predicate {
+            Predicate::Equals { key, value } => store_val_pinned
+                .into_iter()
+                .filter(|(_, (_, store_value))| {
+                    store_value.get(key).map(|v| v.eq(value)).unwrap_or(false)
+                })
+                .map(|(k, _)| k.clone())
+                .collect(),
+            Predicate::NotEquals { key, value } => store_val_pinned
+                .into_iter()
+                .filter(|(_, (_, store_value))| {
+                    store_value.get(key).map(|v| !v.eq(value)).unwrap_or(true)
+                })
+                .map(|(k, _)| k.clone())
+                .collect(),
+            Predicate::In { key, value } => store_val_pinned
+                .into_iter()
+                .filter(|(_, (_, store_value))| {
+                    store_value
+                        .get(key)
+                        .map(|v| value.contains(v))
+                        .unwrap_or(false)
+                })
+                .map(|(k, _)| k.clone())
+                .collect(),
+            Predicate::NotIn { key, value } => store_val_pinned
+                .into_iter()
+                .filter(|(_, (_, store_value))| {
+                    store_value
+                        .get(key)
+                        .map(|v| !value.contains(v))
+                        .unwrap_or(true)
+                })
+                .map(|(k, _)| k.clone())
+                .collect(),
+        };
+        Ok(res)
     }
 
     #[tracing::instrument(skip_all)]
@@ -799,10 +846,7 @@ mod tests {
             value: MetadataValue::RawString("earth".into()),
         }));
         let res = handler.get_pred_in_store(&even_store, &condition);
-        assert_eq!(
-            res.unwrap_err(),
-            ServerError::PredicateNotFound(MetadataKey::new("planet".into()))
-        );
+        assert_eq!(res.unwrap().len(), 2);
         handler
             .create_index(
                 &even_store,

--- a/sdk/ahnlich-client-py/ahnlich_client_py/tests/test_client_store_commands.py
+++ b/sdk/ahnlich-client-py/ahnlich_client_py/tests/test_client_store_commands.py
@@ -164,7 +164,7 @@ def test_client_get_key_succeeds(module_scopped_ahnlich_db, store_key, store_val
     assert actual_response[0][0].data == store_key.data
 
 
-def test_client_get_by_predicate_fails_no_index_found_in_store(
+def test_client_get_by_predicate_succeeds_with_no_index_in_store(
     module_scopped_ahnlich_db,
 ):
     port = module_scopped_ahnlich_db
@@ -186,11 +186,7 @@ def test_client_get_by_predicate_fails_no_index_found_in_store(
         )
     finally:
         db_client.cleanup()
-    assert isinstance(response.results[0], server_response.Result__Err)
-
-    error_message = "Predicate job not found in store"
-    error_response = response.results[0].value
-    assert error_message.lower() in error_response.lower()
+    assert isinstance(response.results[0], server_response.Result__Ok)
 
 
 def test_client_create_index_succeeds(module_scopped_ahnlich_db):


### PR DESCRIPTION
Having an index is no longer necessary to check a predicate as we can use the original store as well whenever we don't find a predicate