### PR TITLE
Adding bench group for retrieval as store size scales

### DIFF
--- a/ahnlich/db/benches/database.rs
+++ b/ahnlich/db/benches/database.rs
@@ -1,6 +1,7 @@
 use ahnlich_db::engine::store::StoreHandler;
 use ahnlich_types::keyval::StoreKey;
 use ahnlich_types::keyval::StoreName;
+use ahnlich_types::similarity::Algorithm;
 use criterion::{criterion_group, criterion_main, Criterion};
 use ndarray::Array;
 use ndarray::Array1;
@@ -13,6 +14,53 @@ fn initialize_store_handler() -> Arc<StoreHandler> {
     let write_flag = Arc::new(AtomicBool::new(false));
     let handler = Arc::new(StoreHandler::new(write_flag));
     handler
+}
+
+fn bench_retrieval(c: &mut Criterion) {
+    let store_name = "TestRetrieval";
+    let sizes = [100, 1000, 10000, 100000];
+
+    let mut group = c.benchmark_group("store_retrieval_no_condition");
+    for size in sizes {
+        let handler = initialize_store_handler();
+        let dimension = 1024;
+        let bulk_insert: Vec<_> = (0..size)
+            .map(|_| {
+                let random_array: Array1<f32> =
+                    Array::from((0..dimension).map(|_| rand::random()).collect::<Vec<f32>>());
+                (StoreKey(random_array), HashMap::new())
+            })
+            .collect();
+        handler
+            .create_store(
+                StoreName(store_name.to_string()),
+                NonZeroUsize::new(dimension).unwrap(),
+                vec![],
+                true,
+            )
+            .unwrap();
+        handler
+            .set_in_store(&StoreName(store_name.to_string()), bulk_insert.clone())
+            .unwrap();
+        let random_input = StoreKey(Array::from(
+            (0..dimension).map(|_| rand::random()).collect::<Vec<f32>>(),
+        ));
+        group.sampling_mode(criterion::SamplingMode::Flat);
+        group.bench_function(format!("size_{size}"), |b| {
+            b.iter(|| {
+                handler
+                    .get_sim_in_store(
+                        &StoreName(store_name.to_string()),
+                        random_input.clone(),
+                        NonZeroUsize::new(50).unwrap(),
+                        Algorithm::CosineSimilarity,
+                        None,
+                    )
+                    .unwrap();
+            });
+        });
+    }
+    group.finish();
 }
 
 fn bench_insertion(c: &mut Criterion) {
@@ -82,16 +130,23 @@ fn bench_insertion(c: &mut Criterion) {
     group.finish();
 }
 
-fn criterion_config() -> Criterion {
+fn criterion_config(seconds: u64, sample_size: usize) -> Criterion {
     Criterion::default()
-        .measurement_time(std::time::Duration::new(30, 0))
-        .sample_size(10)
+        .measurement_time(std::time::Duration::new(seconds, 0))
+        .sample_size(sample_size)
 }
 
 // group to measure insertion time of 100, 1k, 10k and 100k
 criterion_group! {
     name = insertion;
-    config = criterion_config();
+    config = criterion_config(30, 10);
     targets = bench_insertion
 }
-criterion_main!(insertion);
+
+// group to measure retrieval time of 100, 1k, 10k and 100k
+criterion_group! {
+    name = retrieval;
+    config = criterion_config(30, 10);
+    targets = bench_retrieval
+}
+criterion_main!(insertion, retrieval);

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -152,7 +152,7 @@ impl StoreHandler {
 
     /// Matches GETSIMN - gets all similar from a store that also match a predicate
     #[tracing::instrument(skip(self))]
-    pub(crate) fn get_sim_in_store(
+    pub fn get_sim_in_store(
         &self,
         store_name: &StoreName,
         search_input: StoreKey,


### PR DESCRIPTION
Retrieval is a bit slower than even set but that is to be expected as it is linear. Takes almost 1.74 seconds for a vector search when the store size is about 100k rows. Added some of the results below
We would definitely need to invest in non-linear search algorithms down the line

```
store_retrieval_no_condition/size_100
                        time:   [2.3642 ms 2.3655 ms 2.3669 ms]
                        change: [-99.001% -99.000% -98.999%] (p = 0.00 < 0.05)
                        Performance has improved.
store_retrieval_no_condition/size_1000
                        time:   [17.284 ms 17.303 ms 17.322 ms]
                        change: [-99.901% -99.901% -99.901%] (p = 0.00 < 0.05)
                        Performance has improved.
store_retrieval_no_condition/size_10000
                        time:   [170.90 ms 171.12 ms 171.35 ms]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
store_retrieval_no_condition/size_100000
                        time:   [1.7313 s 1.7335 s 1.7361 s]
```