### PR TITLE
Create Store Validation

### DIFF
--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -30,6 +30,7 @@ ahnlich_similarity = { path = "../similarity", version = "*", features = ["serde
 cap.workspace = true
 deadpool.workspace = true
 nonzero_ext = "0.3.0"
+serde_json.workspace = true
 
 
 [dev-dependencies]

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -32,6 +32,7 @@ deadpool.workspace = true
 nonzero_ext = "0.3.0"
 serde_json.workspace = true
 termcolor = "1.4.1"
+strum = { version = "0.26", features = ["derive"] }
 
 [dev-dependencies]
 db = { path = "../db", version = "*" }

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -31,7 +31,7 @@ cap.workspace = true
 deadpool.workspace = true
 nonzero_ext = "0.3.0"
 serde_json.workspace = true
-
+termcolor = "1.4.1"
 
 [dev-dependencies]
 db = { path = "../db", version = "*" }

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -5,6 +5,8 @@ use crate::engine::ai::{
     models::{Model, ModelInfo},
     AHNLICH_AI_SUPPORTED_MODELS,
 };
+use std::io::Write;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum SupportedModels {
@@ -194,5 +196,21 @@ impl SupportedModelArgs {
         }
         serde_json::to_string_pretty(&output)
             .expect("Failed Generate Supported Models Verbose Text")
+    }
+
+    pub fn output(&self) {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        stdout
+            .set_color(ColorSpec::new().set_fg(Some(Color::Green)))
+            .expect("Failed to set output Color");
+
+        let mut text = "\n\nDisplaying Supported Models \n\n".to_string();
+        if !self.names.is_empty() {
+            text.push_str(&self.list_supported_models_verbose());
+        } else {
+            text.push_str(&self.list_supported_models());
+        }
+
+        writeln!(&mut stdout, "{}", text).expect("Failed to write output");
     }
 }

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -4,7 +4,7 @@ use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum SupportedModels {
     Llama3,
-    Dalla3,
+    Dalle3,
 }
 
 #[derive(Parser)]
@@ -106,7 +106,7 @@ impl Default for AIProxyConfig {
             otel_endpoint: None,
             log_level: String::from("info"),
             maximum_clients: 1000,
-            supported_models: vec![SupportedModels::Llama3, SupportedModels::Dalla3],
+            supported_models: vec![SupportedModels::Llama3, SupportedModels::Dalle3],
         }
     }
 }
@@ -145,7 +145,7 @@ impl From<&AIModel> for SupportedModels {
     fn from(value: &AIModel) -> Self {
         match value {
             AIModel::Llama3 => SupportedModels::Llama3,
-            AIModel::DALLE3 => SupportedModels::Dalla3,
+            AIModel::DALLE3 => SupportedModels::Dalle3,
         }
     }
 }

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -1,4 +1,11 @@
-use clap::{ArgAction, Args, Parser, Subcommand};
+use ahnlich_types::ai::AIModel;
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum SupportedModels {
+    Llama3,
+    Dalla3,
+}
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -73,6 +80,10 @@ pub struct AIProxyConfig {
     ///  Defaults to 1000
     #[arg(long, default_value_t = 1000)]
     pub(crate) maximum_clients: usize,
+
+    /// List of ai models to support in your aiproxy stores
+    #[arg(long, required(true))]
+    pub(crate) supported_models: Vec<SupportedModels>,
 }
 
 impl Default for AIProxyConfig {
@@ -95,6 +106,7 @@ impl Default for AIProxyConfig {
             otel_endpoint: None,
             log_level: String::from("info"),
             maximum_clients: 1000,
+            supported_models: vec![SupportedModels::Llama3, SupportedModels::Dalla3],
         }
     }
 }
@@ -120,5 +132,20 @@ impl AIProxyConfig {
     pub fn set_maximum_clients(mut self, maximum_clients: usize) -> Self {
         self.maximum_clients = maximum_clients;
         self
+    }
+
+    #[cfg(test)]
+    pub fn set_supported_models(mut self, models: Vec<SupportedModels>) -> Self {
+        self.supported_models = models;
+        self
+    }
+}
+
+impl From<&AIModel> for SupportedModels {
+    fn from(value: &AIModel) -> Self {
+        match value {
+            AIModel::Llama3 => SupportedModels::Llama3,
+            AIModel::DALLE3 => SupportedModels::Dalla3,
+        }
     }
 }

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -82,7 +82,7 @@ pub struct AIProxyConfig {
     pub(crate) maximum_clients: usize,
 
     /// List of ai models to support in your aiproxy stores
-    #[arg(long, required(true))]
+    #[arg(long, required(true), value_delimiter = ',')]
     pub(crate) supported_models: Vec<SupportedModels>,
 }
 

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -1,14 +1,12 @@
 use ahnlich_types::ai::AIModel;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
+use strum::VariantArray;
 
-use crate::engine::ai::{
-    models::{Model, ModelInfo},
-    AHNLICH_AI_SUPPORTED_MODELS,
-};
+use crate::engine::ai::models::{Model, ModelInfo};
 use std::io::Write;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, VariantArray)]
 pub enum SupportedModels {
     Llama3,
     Dalle3,
@@ -180,8 +178,9 @@ impl SupportedModelArgs {
     pub fn list_supported_models(&self) -> String {
         let mut output = String::new();
 
-        for aimodel in AHNLICH_AI_SUPPORTED_MODELS.iter() {
-            let model: Model = aimodel.into();
+        for supported_model in SupportedModels::VARIANTS.iter() {
+            let aimodel: AIModel = supported_model.into();
+            let model: Model = (&aimodel).into();
             output.push_str(format!("{}, ", model.model_name()).as_str())
         }
         output

--- a/ahnlich/ai/src/engine/ai/mod.rs
+++ b/ahnlich/ai/src/engine/ai/mod.rs
@@ -1,1 +1,7 @@
 pub mod models;
+use once_cell::sync::Lazy;
+
+use ahnlich_types::ai::AIModel;
+
+pub(crate) static AHNLICH_AI_SUPPORTED_MODELS: Lazy<Vec<AIModel>> =
+    Lazy::new(|| vec![AIModel::Llama3, AIModel::DALLE3]);

--- a/ahnlich/ai/src/engine/ai/mod.rs
+++ b/ahnlich/ai/src/engine/ai/mod.rs
@@ -1,5 +1,5 @@
-mod models;
 use ahnlich_types::keyval::{StoreInput, StoreKey};
+pub(crate) mod models;
 use models::ModelInfo;
 use std::num::NonZeroUsize;
 

--- a/ahnlich/ai/src/engine/ai/mod.rs
+++ b/ahnlich/ai/src/engine/ai/mod.rs
@@ -1,10 +1,1 @@
-use ahnlich_types::keyval::{StoreInput, StoreKey};
-pub(crate) mod models;
-use models::ModelInfo;
-use std::num::NonZeroUsize;
-
-pub trait AIModelManager {
-    fn embedding_size(&self) -> NonZeroUsize;
-    fn model_ndarray(&self, storeinput: &StoreInput) -> StoreKey;
-    fn model_info(&self) -> ModelInfo;
-}
+pub mod models;

--- a/ahnlich/ai/src/engine/ai/mod.rs
+++ b/ahnlich/ai/src/engine/ai/mod.rs
@@ -1,7 +1,1 @@
 pub mod models;
-use once_cell::sync::Lazy;
-
-use ahnlich_types::ai::AIModel;
-
-pub(crate) static AHNLICH_AI_SUPPORTED_MODELS: Lazy<Vec<AIModel>> =
-    Lazy::new(|| vec![AIModel::Llama3, AIModel::DALLE3]);

--- a/ahnlich/ai/src/engine/ai/models.rs
+++ b/ahnlich/ai/src/engine/ai/models.rs
@@ -13,6 +13,7 @@ pub struct ModelInfo {
     pub name: String,
     pub embedding_size: NonZeroUsize,
     pub input_type: AIStoreInputType,
+    pub max_token: NonZeroUsize,
 }
 
 impl AIModelManager for AIModel {
@@ -35,11 +36,13 @@ impl AIModelManager for AIModel {
                 name: String::from("Llama3"),
                 embedding_size: nonzero!(100usize),
                 input_type: AIStoreInputType::RawString,
+                max_token: nonzero!(100usize),
             },
             AIModel::DALLE3 => ModelInfo {
                 name: String::from("DALL.E 3"),
                 embedding_size: nonzero!(300usize),
                 input_type: AIStoreInputType::Image,
+                max_token: nonzero!(300usize),
             },
         }
     }

--- a/ahnlich/ai/src/engine/ai/models.rs
+++ b/ahnlich/ai/src/engine/ai/models.rs
@@ -57,16 +57,21 @@ impl Model {
         StoreKey(Array1::from_iter(0..self.embedding_size().into()).mapv(|v| v as f32 * length))
     }
 
-    /// Returns either the max token size(Text) or max image dimension size(Image) of a model
-    pub fn max_accepted_size(&self) -> NonZeroUsize {
+    pub fn max_input_token(&self) -> Option<NonZeroUsize> {
         match self {
             Model::Text {
                 max_input_tokens, ..
-            } => *max_input_tokens,
+            } => Some(*max_input_tokens),
+            Model::Image { .. } => None,
+        }
+    }
+    pub fn max_image_dimensions(&self) -> Option<NonZeroUsize> {
+        match self {
+            Model::Text { .. } => None,
             Model::Image {
                 max_image_dimensions,
                 ..
-            } => *max_image_dimensions,
+            } => Some(*max_image_dimensions),
         }
     }
 }

--- a/ahnlich/ai/src/engine/ai/models.rs
+++ b/ahnlich/ai/src/engine/ai/models.rs
@@ -4,16 +4,19 @@ use ahnlich_types::{
 };
 use ndarray::Array1;
 use nonzero_ext::nonzero;
+use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 
 pub enum Model {
     Text {
         name: String,
+        description: String,
         embedding_size: NonZeroUsize,
         max_input_tokens: NonZeroUsize,
     },
     Image {
         name: String,
+        description: String,
         max_image_dimensions: NonZeroUsize,
         embedding_size: NonZeroUsize,
     },
@@ -24,11 +27,13 @@ impl From<&AIModel> for Model {
         match value {
             AIModel::Llama3 => Self::Text {
                 name: String::from("Llama3"),
+                description: String::from("Llama3, a text model"),
                 embedding_size: nonzero!(100usize),
                 max_input_tokens: nonzero!(100usize),
             },
             AIModel::DALLE3 => Self::Image {
                 name: String::from("DALL.E 3"),
+                description: String::from("Dalle3, an image model"),
                 embedding_size: nonzero!(300usize),
                 max_image_dimensions: nonzero!(300usize),
             },
@@ -72,6 +77,41 @@ impl Model {
                 max_image_dimensions,
                 ..
             } => Some(*max_image_dimensions),
+        }
+    }
+    pub fn model_name(&self) -> String {
+        match self {
+            Model::Text { name, .. } => name.clone(),
+            Model::Image { name, .. } => name.clone(),
+        }
+    }
+    pub fn model_description(&self) -> String {
+        match self {
+            Model::Text { description, .. } => description.clone(),
+            Model::Image { description, .. } => description.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct ModelInfo {
+    name: String,
+    input_type: String,
+    embedding_size: NonZeroUsize,
+    max_input_tokens: Option<NonZeroUsize>,
+    max_image_dimensions: Option<NonZeroUsize>,
+    description: String,
+}
+
+impl ModelInfo {
+    pub(crate) fn build(model: &Model) -> Self {
+        Self {
+            name: model.model_name(),
+            input_type: model.input_type(),
+            embedding_size: model.embedding_size(),
+            max_input_tokens: model.max_input_token(),
+            max_image_dimensions: model.max_image_dimensions(),
+            description: model.model_description(),
         }
     }
 }

--- a/ahnlich/ai/src/engine/ai/models.rs
+++ b/ahnlich/ai/src/engine/ai/models.rs
@@ -16,6 +16,21 @@ pub struct ModelInfo {
     pub max_token: NonZeroUsize,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TextModelInfo {
+    pub name: String,
+    pub embedding_size: NonZeroUsize,
+    pub input_type: AIStoreInputType,
+    pub max_token: NonZeroUsize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MediaModelInfo {
+    pub name: String,
+    pub embedding_size: NonZeroUsize,
+    pub input_type: AIStoreInputType,
+}
+
 impl AIModelManager for AIModel {
     fn embedding_size(&self) -> NonZeroUsize {
         self.model_info().embedding_size
@@ -44,6 +59,55 @@ impl AIModelManager for AIModel {
                 input_type: AIStoreInputType::Image,
                 max_token: nonzero!(300usize),
             },
+        }
+    }
+}
+
+pub(crate) enum Model {
+    Text {
+        name: String,
+        embedding_size: NonZeroUsize,
+        input_type: AIStoreInputType,
+        max_input_tokens: NonZeroUsize,
+    },
+    Image {
+        name: String,
+        max_image_dimensions: NonZeroUsize,
+        input_type: AIStoreInputType,
+        embedding_size: NonZeroUsize,
+    },
+}
+
+impl From<&AIModel> for Model {
+    fn from(value: &AIModel) -> Self {
+        match value {
+            AIModel::Llama3 => Self::Text {
+                name: String::from("Llama3"),
+                input_type: AIStoreInputType::RawString,
+                embedding_size: nonzero!(100usize),
+                max_input_tokens: nonzero!(100usize),
+            },
+            AIModel::DALLE3 => Self::Image {
+                name: String::from("DALL.E 3"),
+                input_type: AIStoreInputType::Image,
+                embedding_size: nonzero!(300usize),
+                max_image_dimensions: nonzero!(300usize),
+            },
+        }
+    }
+}
+
+impl Model {
+    pub(crate) fn embedding_size(&self) -> NonZeroUsize {
+        match self {
+            Model::Text { embedding_size, .. } => *embedding_size,
+            Model::Image { embedding_size, .. } => *embedding_size,
+        }
+    }
+    pub(crate) fn input_type(&self) -> AIStoreInputType {
+        match self {
+            Model::Text { input_type, .. } => input_type.clone(),
+            Model::Image { input_type, .. } => input_type.clone(),
         }
     }
 }

--- a/ahnlich/ai/src/engine/ai/models.rs
+++ b/ahnlich/ai/src/engine/ai/models.rs
@@ -1,79 +1,20 @@
-use crate::engine::ai::AIModelManager;
 use ahnlich_types::{
     ai::{AIModel, AIStoreInputType},
     keyval::{StoreInput, StoreKey},
 };
 use ndarray::Array1;
 use nonzero_ext::nonzero;
-use serde::{Deserialize, Serialize};
 use std::num::NonZeroUsize;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ModelInfo {
-    pub name: String,
-    pub embedding_size: NonZeroUsize,
-    pub input_type: AIStoreInputType,
-    pub max_token: NonZeroUsize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TextModelInfo {
-    pub name: String,
-    pub embedding_size: NonZeroUsize,
-    pub input_type: AIStoreInputType,
-    pub max_token: NonZeroUsize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct MediaModelInfo {
-    pub name: String,
-    pub embedding_size: NonZeroUsize,
-    pub input_type: AIStoreInputType,
-}
-
-impl AIModelManager for AIModel {
-    fn embedding_size(&self) -> NonZeroUsize {
-        self.model_info().embedding_size
-    }
-    // TODO: model ndarray values is based on length of string or vec, so for now make sure strings
-    // or vecs have different lengths
-    fn model_ndarray(&self, storeinput: &StoreInput) -> StoreKey {
-        let length = storeinput.len() as f32;
-        StoreKey(
-            Array1::from_iter(0..self.model_info().embedding_size.into())
-                .mapv(|v| v as f32 * length),
-        )
-    }
-
-    fn model_info(&self) -> ModelInfo {
-        match self {
-            AIModel::Llama3 => ModelInfo {
-                name: String::from("Llama3"),
-                embedding_size: nonzero!(100usize),
-                input_type: AIStoreInputType::RawString,
-                max_token: nonzero!(100usize),
-            },
-            AIModel::DALLE3 => ModelInfo {
-                name: String::from("DALL.E 3"),
-                embedding_size: nonzero!(300usize),
-                input_type: AIStoreInputType::Image,
-                max_token: nonzero!(300usize),
-            },
-        }
-    }
-}
-
-pub(crate) enum Model {
+pub enum Model {
     Text {
         name: String,
         embedding_size: NonZeroUsize,
-        input_type: AIStoreInputType,
         max_input_tokens: NonZeroUsize,
     },
     Image {
         name: String,
         max_image_dimensions: NonZeroUsize,
-        input_type: AIStoreInputType,
         embedding_size: NonZeroUsize,
     },
 }
@@ -83,13 +24,11 @@ impl From<&AIModel> for Model {
         match value {
             AIModel::Llama3 => Self::Text {
                 name: String::from("Llama3"),
-                input_type: AIStoreInputType::RawString,
                 embedding_size: nonzero!(100usize),
                 max_input_tokens: nonzero!(100usize),
             },
             AIModel::DALLE3 => Self::Image {
                 name: String::from("DALL.E 3"),
-                input_type: AIStoreInputType::Image,
                 embedding_size: nonzero!(300usize),
                 max_image_dimensions: nonzero!(300usize),
             },
@@ -98,16 +37,36 @@ impl From<&AIModel> for Model {
 }
 
 impl Model {
-    pub(crate) fn embedding_size(&self) -> NonZeroUsize {
+    pub fn embedding_size(&self) -> NonZeroUsize {
         match self {
             Model::Text { embedding_size, .. } => *embedding_size,
             Model::Image { embedding_size, .. } => *embedding_size,
         }
     }
-    pub(crate) fn input_type(&self) -> AIStoreInputType {
+    pub fn input_type(&self) -> String {
         match self {
-            Model::Text { input_type, .. } => input_type.clone(),
-            Model::Image { input_type, .. } => input_type.clone(),
+            Model::Text { .. } => AIStoreInputType::RawString.to_string(),
+            Model::Image { .. } => AIStoreInputType::Image.to_string(),
+        }
+    }
+
+    // TODO: model ndarray values is based on length of string or vec, so for now make sure strings
+    // or vecs have different lengths
+    pub fn model_ndarray(&self, storeinput: &StoreInput) -> StoreKey {
+        let length = storeinput.len() as f32;
+        StoreKey(Array1::from_iter(0..self.embedding_size().into()).mapv(|v| v as f32 * length))
+    }
+
+    /// Returns either the max token size(Text) or max image dimension size(Image) of a model
+    pub fn max_accepted_size(&self) -> NonZeroUsize {
+        match self {
+            Model::Text {
+                max_input_tokens, ..
+            } => *max_input_tokens,
+            Model::Image {
+                max_image_dimensions,
+                ..
+            } => *max_image_dimensions,
         }
     }
 }

--- a/ahnlich/ai/src/engine/store.rs
+++ b/ahnlich/ai/src/engine/store.rs
@@ -1,4 +1,5 @@
 use crate::cli::server::SupportedModels;
+use crate::engine::ai::models::Model;
 use crate::AHNLICH_AI_RESERVED_META_KEY;
 use crate::{engine::ai::AIModelManager, error::AIProxyError};
 use ahnlich_types::ai::{
@@ -130,11 +131,11 @@ impl AIStoreHandler {
         let store = self.get(store_name)?;
 
         let store_input_type: AIStoreInputType = (&store_input).into();
-        let store_index_model_info = store.index_model.model_info();
+        let index_model_repr: Model = (&store.index_model).into();
 
-        if store_input_type != store_index_model_info.input_type {
+        if store_input_type != index_model_repr.input_type() {
             return Err(AIProxyError::StoreSetTypeMismatchError {
-                store_index_model_type: store_index_model_info.input_type,
+                store_index_model_type: index_model_repr.input_type(),
                 storeinput_type: store_input_type,
             });
         }

--- a/ahnlich/ai/src/error.rs
+++ b/ahnlich/ai/src/error.rs
@@ -25,10 +25,10 @@ pub enum AIProxyError {
         store_query_model_type: AIStoreInputType,
         storeinput_type: AIStoreInputType,
     },
-    #[error("Cannot Set Input. Store expects [{store_index_model_type}], input type [{storeinput_type}] was provided")]
+    #[error("Cannot Set Input. Store expects [{index_model_type}], input type [{storeinput_type}] was provided")]
     StoreSetTypeMismatchError {
-        store_index_model_type: AIStoreInputType,
-        storeinput_type: AIStoreInputType,
+        index_model_type: String,
+        storeinput_type: String,
     },
 
     #[error("Max Token Exceeded. Model Expects [{max_token_size}], input type was [{input_token_size}] ")]

--- a/ahnlich/ai/src/error.rs
+++ b/ahnlich/ai/src/error.rs
@@ -31,9 +31,9 @@ pub enum AIProxyError {
         storeinput_type: AIStoreInputType,
     },
 
-    #[error("Max Token Exceeded. Model Expects [{model_embedding_size}], input type was [{input_token_size}] ")]
+    #[error("Max Token Exceeded. Model Expects [{max_token_size}], input type was [{input_token_size}] ")]
     TokenExceededError {
-        model_embedding_size: usize,
+        max_token_size: usize,
         input_token_size: usize,
     },
 
@@ -50,4 +50,7 @@ pub enum AIProxyError {
         input_type: AIStoreInputType,
         preprocess_action: PreprocessAction,
     },
+
+    #[error("index_model or query_model not selected during aiproxy startup")]
+    AIModelNotInitialized,
 }

--- a/ahnlich/ai/src/error.rs
+++ b/ahnlich/ai/src/error.rs
@@ -53,4 +53,10 @@ pub enum AIProxyError {
 
     #[error("index_model or query_model not selected during aiproxy startup")]
     AIModelNotInitialized,
+
+    #[error("Dimensions Mismatch between index [{index_model_dim}], and Query [{query_model_dim}] Models")]
+    DimensionsMismatchError {
+        index_model_dim: usize,
+        query_model_dim: usize,
+    },
 }

--- a/ahnlich/ai/src/main.rs
+++ b/ahnlich/ai/src/main.rs
@@ -10,6 +10,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let server = ahnlich_ai_proxy::server::handler::AIProxyServer::new(config).await?;
             server.start().await?;
         }
+        ahnlich_ai_proxy::cli::Commands::SupportedModels(config) => {
+            println!("\nDisplaying Supported Models \n");
+            if config.names.len() > 0 {
+                println!("{}", config.list_supported_models_verbose())
+            } else {
+                println!("{}", config.list_supported_models())
+            }
+        }
     }
     Ok(())
 }

--- a/ahnlich/ai/src/main.rs
+++ b/ahnlich/ai/src/main.rs
@@ -10,14 +10,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let server = ahnlich_ai_proxy::server::handler::AIProxyServer::new(config).await?;
             server.start().await?;
         }
-        ahnlich_ai_proxy::cli::Commands::SupportedModels(config) => {
-            println!("\nDisplaying Supported Models \n");
-            if config.names.len() > 0 {
-                println!("{}", config.list_supported_models_verbose())
-            } else {
-                println!("{}", config.list_supported_models())
-            }
-        }
+        ahnlich_ai_proxy::cli::Commands::SupportedModels(config) => config.output(),
     }
     Ok(())
 }

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -54,7 +54,8 @@ impl AIProxyServer {
         }
         let write_flag = Arc::new(AtomicBool::new(false));
         let db_client = Self::build_db_client(&config).await;
-        let mut store_handler = AIStoreHandler::new(write_flag.clone());
+        let mut store_handler =
+            AIStoreHandler::new(write_flag.clone(), config.supported_models.clone());
         let client_handler = Arc::new(ClientHandler::new(config.maximum_clients));
 
         // persistence

--- a/ahnlich/ai/src/server/task.rs
+++ b/ahnlich/ai/src/server/task.rs
@@ -1,3 +1,4 @@
+use crate::engine::ai::models::Model;
 use crate::server::handler::AI_ALLOCATOR;
 use ahnlich_client_rs::db::DbClient;
 use ahnlich_types::ai::{AIQuery, AIServerQuery, AIServerResponse, AIServerResult};
@@ -9,13 +10,12 @@ use ahnlich_types::version::VERSION;
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::vec;
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
 use utils::client::ClientHandler;
 use utils::protocol::AhnlichProtocol;
 
-use crate::engine::{ai::AIModelManager, store::AIStoreHandler};
+use crate::engine::store::AIStoreHandler;
 use crate::error::AIProxyError;
 use crate::AHNLICH_AI_RESERVED_META_KEY;
 
@@ -68,11 +68,12 @@ impl AhnlichProtocol for AIProxyTask {
                         Err(format!("Cannot use {} keyword", default_metadata_key))
                     } else {
                         predicates.insert(default_metadata_key.clone());
+                        let model: Model = (&index_model).into();
                         match self
                             .db_client
                             .create_store(
                                 store.clone(),
-                                index_model.embedding_size(),
+                                model.max_accepted_size(),
                                 predicates,
                                 non_linear_indices,
                                 false,

--- a/ahnlich/ai/src/server/task.rs
+++ b/ahnlich/ai/src/server/task.rs
@@ -73,7 +73,7 @@ impl AhnlichProtocol for AIProxyTask {
                             .db_client
                             .create_store(
                                 store.clone(),
-                                model.max_accepted_size(),
+                                model.embedding_size(),
                                 predicates,
                                 non_linear_indices,
                                 false,

--- a/ahnlich/ai/src/tests/aiproxy_test.rs
+++ b/ahnlich/ai/src/tests/aiproxy_test.rs
@@ -18,7 +18,7 @@ use std::{collections::HashSet, num::NonZeroUsize, sync::atomic::Ordering};
 
 use crate::{
     cli::{server::SupportedModels, AIProxyConfig},
-    engine::ai::AIModelManager,
+    engine::ai::models::Model,
     error::AIProxyError,
     server::handler::AIProxyServer,
 };
@@ -146,12 +146,13 @@ async fn test_ai_proxy_create_store_success() {
     // list stores to verify it's present.
     let message = AIServerQuery::from_queries(&[AIQuery::ListStores]);
     let mut expected = AIServerResult::with_capacity(1);
+    let llama3_model: Model = (&AIModel::Llama3).into();
     expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
         AIStoreInfo {
             name: store_name.clone(),
             query_model: AIModel::Llama3,
             index_model: AIModel::Llama3,
-            embedding_size: AIModel::Llama3.embedding_size().into(),
+            embedding_size: llama3_model.embedding_size().into(),
         },
     ]))));
     let mut reader = BufReader::new(second_stream);
@@ -553,13 +554,14 @@ async fn test_ai_proxy_test_with_persistence() {
     let message = AIServerQuery::from_queries(&[AIQuery::ListStores]);
 
     let mut expected = AIServerResult::with_capacity(1);
+    let llama3_model: Model = (&AIModel::Llama3).into();
 
     expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
         AIStoreInfo {
             name: store_name_2.clone(),
             query_model: AIModel::Llama3,
             index_model: AIModel::Llama3,
-            embedding_size: AIModel::Llama3.embedding_size().into(),
+            embedding_size: llama3_model.embedding_size().into(),
         },
     ]))));
 
@@ -588,13 +590,14 @@ async fn test_ai_proxy_destroy_database() {
     ]);
     let mut expected = AIServerResult::with_capacity(4);
 
+    let llama3_model: Model = (&AIModel::Llama3).into();
     expected.push(Ok(AIServerResponse::Unit));
     expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
         AIStoreInfo {
             name: store_name,
             query_model: AIModel::Llama3,
             index_model: AIModel::Llama3,
-            embedding_size: AIModel::Llama3.embedding_size().into(),
+            embedding_size: llama3_model.embedding_size().into(),
         },
     ]))));
     expected.push(Ok(AIServerResponse::Del(1)));
@@ -673,6 +676,7 @@ async fn test_ai_proxy_binary_store_actions() {
     ]);
 
     let mut expected = AIServerResult::with_capacity(7);
+    let dalle3_model: Model = (&AIModel::DALLE3).into();
 
     expected.push(Ok(AIServerResponse::Unit));
     expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
@@ -680,7 +684,7 @@ async fn test_ai_proxy_binary_store_actions() {
             name: store_name,
             query_model: AIModel::Llama3,
             index_model: AIModel::DALLE3,
-            embedding_size: AIModel::DALLE3.embedding_size().into(),
+            embedding_size: dalle3_model.embedding_size().into(),
         },
     ]))));
     expected.push(Ok(AIServerResponse::CreateIndex(2)));

--- a/ahnlich/ai/src/tests/aiproxy_test.rs
+++ b/ahnlich/ai/src/tests/aiproxy_test.rs
@@ -16,7 +16,12 @@ use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use std::{collections::HashSet, num::NonZeroUsize, sync::atomic::Ordering};
 
-use crate::{cli::AIProxyConfig, engine::ai::AIModelManager, server::handler::AIProxyServer};
+use crate::{
+    cli::{server::SupportedModels, AIProxyConfig},
+    engine::ai::AIModelManager,
+    error::AIProxyError,
+    server::handler::AIProxyServer,
+};
 use ahnlich_types::bincode::BinCodeSerAndDeser;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -35,6 +40,12 @@ static AI_CONFIG_WITH_PERSISTENCE: Lazy<AIProxyConfig> = Lazy::new(|| {
         .os_select_port()
         .set_persistence_interval(200)
         .set_persist_location((*PERSISTENCE_FILE).clone())
+});
+
+static AI_CONFIG_LIMITED_MODELS: Lazy<AIProxyConfig> = Lazy::new(|| {
+    AIProxyConfig::default()
+        .os_select_port()
+        .set_supported_models(vec![SupportedModels::Llama3])
 });
 
 async fn get_server_response(
@@ -101,6 +112,7 @@ async fn provision_test_servers() -> SocketAddr {
 
     ai_address
 }
+
 #[tokio::test]
 async fn test_simple_ai_proxy_ping() {
     let address = provision_test_servers().await;
@@ -737,6 +749,45 @@ async fn test_ai_proxy_binary_store_set_text_and_binary_fails() {
         "Cannot Set Input. Store expects [RawString], input type [Image] was provided".to_string(),
     ));
     expected.push(Ok(AIServerResponse::Del(1)));
+
+    let connected_stream = TcpStream::connect(address).await.unwrap();
+    let mut reader = BufReader::new(connected_stream);
+
+    query_server_assert_result(&mut reader, message, expected).await;
+}
+
+#[tokio::test]
+async fn test_ai_proxy_create_store_errors_unsupported_models() {
+    let server = Server::new(&CONFIG)
+        .await
+        .expect("Could not initialize server");
+    let db_port = server.local_addr().unwrap().port();
+    let mut config = AI_CONFIG_LIMITED_MODELS.clone();
+    config.db_port = db_port;
+
+    let ai_server = AIProxyServer::new(config)
+        .await
+        .expect("Could not initialize ai proxy");
+
+    let address = ai_server.local_addr().expect("Could not get local addr");
+    let _ = tokio::spawn(async move { server.start().await });
+    // start up ai proxy
+    let _ = tokio::spawn(async move { ai_server.start().await });
+    // Allow some time for the servers to start
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let store_name = StoreName(String::from("Error Handling Store"));
+    let message = AIServerQuery::from_queries(&[AIQuery::CreateStore {
+        store: store_name.clone(),
+        query_model: AIModel::DALLE3,
+        index_model: AIModel::Llama3,
+        predicates: HashSet::new(),
+        non_linear_indices: HashSet::new(),
+    }]);
+
+    let mut expected = AIServerResult::with_capacity(1);
+
+    expected.push(Err(AIProxyError::AIModelNotInitialized.to_string()));
 
     let connected_stream = TcpStream::connect(address).await.unwrap();
     let mut reader = BufReader::new(connected_stream);

--- a/ahnlich/client/src/ai.rs
+++ b/ahnlich/client/src/ai.rs
@@ -324,7 +324,7 @@ impl AIClient {
 mod tests {
     use super::*;
     use ahnlich_ai_proxy::cli::AIProxyConfig;
-    use ahnlich_ai_proxy::{engine::ai::AIModelManager, server::handler::AIProxyServer};
+    use ahnlich_ai_proxy::{engine::ai::models::Model, server::handler::AIProxyServer};
     use ahnlich_db::cli::ServerConfig;
     use ahnlich_db::server::handler::Server;
     use once_cell::sync::Lazy;
@@ -444,16 +444,17 @@ mod tests {
         expected.push(Ok(AIServerResponse::Unit));
         expected.push(Err("Store Main already exists".to_string()));
         expected.push(Ok(AIServerResponse::Unit));
+        let llama3_model: Model = (&AIModel::Llama3).into();
         expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
             AIStoreInfo {
                 name: StoreName("Main".to_string()),
-                embedding_size: AIModel::Llama3.embedding_size().into(),
+                embedding_size: llama3_model.embedding_size().into(),
                 query_model: AIModel::Llama3,
                 index_model: AIModel::Llama3,
             },
             AIStoreInfo {
                 name: StoreName("Less".to_string()),
-                embedding_size: AIModel::Llama3.embedding_size().into(),
+                embedding_size: llama3_model.embedding_size().into(),
                 query_model: AIModel::Llama3,
                 index_model: AIModel::Llama3,
             },
@@ -548,22 +549,24 @@ mod tests {
         expected.push(Ok(AIServerResponse::Unit));
         expected.push(Ok(AIServerResponse::Unit));
         expected.push(Ok(AIServerResponse::Unit));
+
+        let llama3_model: Model = (&AIModel::Llama3).into();
         expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
             AIStoreInfo {
                 name: StoreName("Main".to_string()),
-                embedding_size: AIModel::Llama3.embedding_size().into(),
+                embedding_size: llama3_model.embedding_size().into(),
                 query_model: AIModel::Llama3,
                 index_model: AIModel::Llama3,
             },
             AIStoreInfo {
                 name: StoreName("Main2".to_string()),
-                embedding_size: AIModel::Llama3.embedding_size().into(),
+                embedding_size: llama3_model.embedding_size().into(),
                 query_model: AIModel::Llama3,
                 index_model: AIModel::Llama3,
             },
             AIStoreInfo {
                 name: StoreName("Less".to_string()),
-                embedding_size: AIModel::Llama3.embedding_size().into(),
+                embedding_size: llama3_model.embedding_size().into(),
                 query_model: AIModel::Llama3,
                 index_model: AIModel::Llama3,
             },
@@ -645,13 +648,14 @@ mod tests {
         let mut expected = AIServerResult::with_capacity(6);
 
         expected.push(Ok(AIServerResponse::Unit));
+        let llama3_model: Model = (&AIModel::Llama3).into();
         expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
             AIStoreInfo {
                 name: store_name.clone(),
                 query_model: AIModel::Llama3,
                 index_model: AIModel::Llama3,
 
-                embedding_size: AIModel::Llama3.embedding_size().into(),
+                embedding_size: llama3_model.embedding_size().into(),
             },
         ]))));
         expected.push(Ok(AIServerResponse::CreateIndex(2)));
@@ -773,12 +777,13 @@ mod tests {
         let mut expected = AIServerResult::with_capacity(7);
 
         expected.push(Ok(AIServerResponse::Unit));
+        let dalle3_model: Model = (&AIModel::DALLE3).into();
         expected.push(Ok(AIServerResponse::StoreList(HashSet::from_iter([
             AIStoreInfo {
                 name: store_name,
                 query_model: AIModel::DALLE3,
                 index_model: AIModel::DALLE3,
-                embedding_size: AIModel::DALLE3.embedding_size().into(),
+                embedding_size: dalle3_model.embedding_size().into(),
             },
         ]))));
         expected.push(Ok(AIServerResponse::CreateIndex(2)));

--- a/sdk/ahnlich-client-py/ahnlich_client_py/tests/conftest.py
+++ b/sdk/ahnlich-client-py/ahnlich_client_py/tests/conftest.py
@@ -110,7 +110,9 @@ def aiproxy_default_ahnlich_db():
 @pytest.fixture
 def spin_up_ahnlich_ai(ai_random_port, aiproxy_default_ahnlich_db):
     port = ai_random_port
-    command = f"cargo run --bin ai start --port {port}".split(" ")
+    command = f"cargo run --bin ai start --supported-models dalle3 --supported-models llama3 --port {port}".split(
+        " "
+    )
     process = subprocess.Popen(args=command, cwd=config.AHNLICH_BIN_DIR)
     while not is_port_occupied(port):
         time.sleep(0.2)
@@ -124,7 +126,9 @@ def spin_up_ahnlich_ai(ai_random_port, aiproxy_default_ahnlich_db):
 @pytest.fixture(scope="module")
 def module_scopped_ahnlich_ai():
     port = 9001
-    command = f"cargo run --bin ai start --port {port}".split(" ")
+    command = f"cargo run --bin ai start --supported-models dalle3 --supported-models llama3 --port {port}".split(
+        " "
+    )
     process = subprocess.Popen(args=command, cwd=config.AHNLICH_BIN_DIR)
     while not is_port_occupied(port):
         time.sleep(0.2)

--- a/sdk/ahnlich-client-py/ahnlich_client_py/tests/conftest.py
+++ b/sdk/ahnlich-client-py/ahnlich_client_py/tests/conftest.py
@@ -110,7 +110,7 @@ def aiproxy_default_ahnlich_db():
 @pytest.fixture
 def spin_up_ahnlich_ai(ai_random_port, aiproxy_default_ahnlich_db):
     port = ai_random_port
-    command = f"cargo run --bin ai start --supported-models dalle3 --supported-models llama3 --port {port}".split(
+    command = f"cargo run --bin ai start --supported-models dalle3,llama3 --port {port}".split(
         " "
     )
     process = subprocess.Popen(args=command, cwd=config.AHNLICH_BIN_DIR)
@@ -126,7 +126,7 @@ def spin_up_ahnlich_ai(ai_random_port, aiproxy_default_ahnlich_db):
 @pytest.fixture(scope="module")
 def module_scopped_ahnlich_ai():
     port = 9001
-    command = f"cargo run --bin ai start --supported-models dalle3 --supported-models llama3 --port {port}".split(
+    command = f"cargo run --bin ai start --supported-models dalle3,llama3 --port {port}".split(
         " "
     )
     process = subprocess.Popen(args=command, cwd=config.AHNLICH_BIN_DIR)


### PR DESCRIPTION
- On creating a store, validate index and query models against supported models selected on AIProxy startup. We error if either the index or query models don't exist in the supported model's Vec.
- Added a new field max_token to specify the maximum token a model would accept
- Swap out AIModelManager Trait for a Model Enum of Image and Text variants, subsequent variants can be added when we support other models
- Added Subcommand to display supported models in verbose or limited mode