### PR TITLE
Unifying most of the logic for server standardization

### DIFF
--- a/ahnlich/Cargo.toml
+++ b/ahnlich/Cargo.toml
@@ -35,9 +35,10 @@ tokio = { version = "1.37.0", features = [
   "signal"
 ]}
 tokio-graceful = "0.1.6"
+tokio-util = { version = "0.7.11", features = ["rt"] }
 rand = "0.8"
 rayon = "1.10"
-cap = "0.1.2"
 deadpool = { version = "0.10", features = ["rt_tokio_1"]}
 opentelemetry =  { version = "0.23.0", features = ["trace"] }
 tracing-opentelemetry = "0.24.0"
+log = "0.4"

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -27,17 +27,18 @@ async-trait.workspace = true
 utils = { path = "../utils", version = "*" }
 ahnlich_types = { path = "../types", version = "*" }
 tokio-graceful.workspace = true
+tokio-util.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
 tracer = { path = "../tracer", version = "*" }
 ahnlich_client_rs = { path = "../client", version = "*" }
 ahnlich_similarity = { path = "../similarity", version = "*", features = ["serde"] }
-cap.workspace = true
 deadpool.workspace = true
 nonzero_ext = "0.3.0"
 serde_json.workspace = true
 termcolor = "1.4.1"
 strum = { version = "0.26", features = ["derive"] }
+log.workspace = true
 
 [dev-dependencies]
 db = { path = "../db", version = "*" }

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -45,6 +45,9 @@ pub struct AIProxyConfig {
     /// persistence location
     #[arg(long, requires_if("true", "enable_persistence"))]
     pub(crate) persist_location: Option<std::path::PathBuf>,
+    /// Controls whether we crash or not on startup if persisting load fails
+    #[arg(long, default_value_t = false, action=ArgAction::SetFalse)]
+    pub(crate) fail_on_startup_if_persist_load_fails: bool,
 
     /// persistence interval in milliseconds
     /// A new persistence round would be scheduled for persistence_interval into the future after
@@ -101,6 +104,7 @@ impl Default for AIProxyConfig {
             port: 1370,
             enable_persistence: false,
             persist_location: None,
+            fail_on_startup_if_persist_load_fails: false,
             persistence_interval: 1000 * 60 * 5,
 
             db_host: String::from("127.0.0.1"),

--- a/ahnlich/ai/src/engine/store.rs
+++ b/ahnlich/ai/src/engine/store.rs
@@ -17,6 +17,7 @@ use std::collections::HashSet as StdHashSet;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use utils::server::AhnlichPersistenceUtils;
 
 /// Contains all the stores that have been created in memory
 #[derive(Debug)]
@@ -29,6 +30,20 @@ pub struct AIStoreHandler {
 
 pub type AIStores = Arc<ConcurrentHashMap<StoreName, Arc<AIStore>>>;
 
+impl AhnlichPersistenceUtils for AIStoreHandler {
+    type PersistenceObject = AIStores;
+
+    #[tracing::instrument(skip_all)]
+    fn write_flag(&self) -> Arc<AtomicBool> {
+        self.write_flag.clone()
+    }
+
+    #[tracing::instrument(skip(self))]
+    fn get_snapshot(&self) -> Self::PersistenceObject {
+        self.stores.clone()
+    }
+}
+
 impl AIStoreHandler {
     pub fn new(write_flag: Arc<AtomicBool>, supported_models: Vec<SupportedModels>) -> Self {
         Self {
@@ -36,15 +51,6 @@ impl AIStoreHandler {
             write_flag,
             supported_models,
         }
-    }
-    #[tracing::instrument(skip(self))]
-    pub(crate) fn get_stores(&self) -> AIStores {
-        self.stores.clone()
-    }
-
-    #[cfg(test)]
-    pub fn write_flag(&self) -> Arc<AtomicBool> {
-        self.write_flag.clone()
     }
 
     #[tracing::instrument(skip(self))]

--- a/ahnlich/ai/src/engine/store.rs
+++ b/ahnlich/ai/src/engine/store.rs
@@ -17,7 +17,7 @@ use std::collections::HashSet as StdHashSet;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use utils::server::AhnlichPersistenceUtils;
+use utils::persistence::AhnlichPersistenceUtils;
 
 /// Contains all the stores that have been created in memory
 #[derive(Debug)]

--- a/ahnlich/ai/src/main.rs
+++ b/ahnlich/ai/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 use std::error::Error;
+use utils::server::AhnlichServerUtils;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -17,7 +17,7 @@ use utils::server::ServerUtilsConfig;
 use ahnlich_client_rs::db::{DbClient, DbConnManager};
 use deadpool::managed::Pool;
 
-const SERVICE_NAME: &'static str = "ahnlich-ai";
+const SERVICE_NAME: &str = "ahnlich-ai";
 
 pub struct AIProxyServer {
     listener: TcpListener,

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -1,26 +1,23 @@
 use crate::cli::AIProxyConfig;
 use crate::engine::store::AIStoreHandler;
 use crate::server::task::AIProxyTask;
-use ahnlich_types::db::ConnectedClient;
-use cap::Cap;
-use std::alloc;
+use ahnlich_types::client::ConnectedClient;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
 use std::{io::Result as IoResult, sync::Arc};
 use tokio::io::BufReader;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::select;
 use tokio_graceful::Shutdown;
-use tracing::Instrument;
-use utils::{client::ClientHandler, persistence::Persistence, protocol::AhnlichProtocol};
+use tokio_util::sync::CancellationToken;
+use utils::client::ClientHandler;
+use utils::persistence::Persistence;
+use utils::server::AhnlichServerUtils;
+use utils::server::ServerUtilsConfig;
 
 use ahnlich_client_rs::db::{DbClient, DbConnManager};
 use deadpool::managed::Pool;
 
-// Creates an issue since there's already a global allocator in db
-//#[global_allocator]
-pub(super) static AI_ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());
+const SERVICE_NAME: &'static str = "ahnlich-ai";
 
 pub struct AIProxyServer {
     listener: TcpListener,
@@ -28,118 +25,45 @@ pub struct AIProxyServer {
     client_handler: Arc<ClientHandler>,
     store_handler: Arc<AIStoreHandler>,
     shutdown_token: Shutdown,
+    cancellation_token: CancellationToken,
     db_client: Arc<DbClient>,
 }
 
-impl AIProxyServer {
-    pub async fn new(config: AIProxyConfig) -> IoResult<Self> {
-        let shutdown_token = Shutdown::default();
-        Self::build(config, shutdown_token).await
-    }
+impl AhnlichServerUtils for AIProxyServer {
+    type Task = AIProxyTask;
+    type PersistenceTask = AIStoreHandler;
 
-    pub async fn build(config: AIProxyConfig, shutdown_token: Shutdown) -> IoResult<Self> {
-        AI_ALLOCATOR
-            .set_limit(config.allocator_size)
-            .expect("Could not set up ai-proxy with allocator_size");
-
-        let listener =
-            tokio::net::TcpListener::bind(format!("{}:{}", &config.host, &config.port)).await?;
-        // Enable tracing
-        if config.enable_tracing {
-            let otel_url = config
-                .otel_endpoint
-                .to_owned()
-                .unwrap_or("http://127.0.0.1:4317".to_string());
-            tracer::init_tracing("ahnlich-ai", Some(&config.log_level), &otel_url)
-        }
-        let write_flag = Arc::new(AtomicBool::new(false));
-        let db_client = Self::build_db_client(&config).await;
-        let mut store_handler =
-            AIStoreHandler::new(write_flag.clone(), config.supported_models.clone());
-        let client_handler = Arc::new(ClientHandler::new(config.maximum_clients));
-
-        // persistence
-        if let Some(persist_location) = &config.persist_location {
-            match Persistence::load_snapshot(persist_location) {
-                Err(e) => {
-                    tracing::error!("Failed to load snapshot from persist location {e}");
-                }
-                Ok(snapshot) => {
-                    store_handler.use_snapshot(snapshot);
-                }
-            }
-            // spawn the persistence task
-            let mut persistence_task = Persistence::task(
-                write_flag,
-                config.persistence_interval,
-                persist_location,
-                store_handler.get_stores(),
-            );
-            shutdown_token
-                .spawn_task_fn(|guard| async move { persistence_task.monitor(guard).await });
-        };
-
-        Ok(Self {
-            listener,
-            shutdown_token,
-            client_handler,
-            store_handler: Arc::new(store_handler),
-            config,
-            db_client: Arc::new(db_client),
-        })
-    }
-    /// starts accepting connections using the listener and processing the incoming streams
-    ///
-    /// listens for a ctrl_c signals to cancel spawned tasks
-    pub async fn start(self) -> IoResult<()> {
-        let server_addr = self.local_addr()?;
-        loop {
-            let shutdown_guard = self.shutdown_token.guard();
-            select! {
-                _ = shutdown_guard.cancelled() => {
-                    // need to drop the shutdown guard used here else self.shutdown times out
-                    drop(shutdown_guard);
-                    self.shutdown().await;
-                    break Ok(());
-                }
-                Ok((stream, connect_addr)) = self.listener.accept() => {
-                    tracing::info!("Connecting to {}", connect_addr);
-                    //  - Spawn a tokio task to handle the command while holding on to a reference to self
-                    //  - Convert the incoming bincode in a chunked manner to a Vec<AIQuery>
-                    //  - Use store_handler to process the queries
-                    //  - Block new incoming connections on shutdown by no longer accepting and then
-                    //  cancelling existing ServerTask or forcing them to run to completion
-
-                    if let Some(connected_client) = self.client_handler.connect(stream.peer_addr()?) {
-                        let mut task = self.create_task(stream, server_addr, connected_client)?;
-                        shutdown_guard.spawn_task_fn(|guard| async move {
-                            if let Err(e) = task.process(guard).instrument(tracing::info_span!("server_task").or_current()).await {
-                                tracing::error!("Error handling connection: {}", e)
-                            };
-                        });
-                    }
-                }
-            }
+    fn config(&self) -> ServerUtilsConfig {
+        ServerUtilsConfig {
+            service_name: SERVICE_NAME,
+            persist_location: &self.config.persist_location,
+            persistence_interval: self.config.persistence_interval,
+            allocator_size: self.config.allocator_size,
         }
     }
 
-    /// stops all tasks and performs cleanup
-    pub async fn shutdown(self) {
-        // TODO: Add cleanup for instance persistence
-        // just cancelling the token alone does not give enough time for each task to shutdown,
-        // there must be other measures in place to ensure proper cleanup
-        if self
-            .shutdown_token
-            .shutdown_with_limit(Duration::from_secs(10))
-            .await
-            .is_err()
-        {
-            tracing::error!("AI-PROXY: shutdown took longer than timeout");
-        }
+    fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancellation_token
     }
 
-    pub fn local_addr(&self) -> IoResult<SocketAddr> {
-        self.listener.local_addr()
+    fn listener(&self) -> &TcpListener {
+        &self.listener
+    }
+
+    fn client_handler(&self) -> &Arc<ClientHandler> {
+        &self.client_handler
+    }
+
+    fn store_handler(&self) -> &Arc<Self::PersistenceTask> {
+        &self.store_handler
+    }
+
+    fn shutdown_token(&self) -> &Shutdown {
+        &self.shutdown_token
+    }
+
+    fn shutdown_token_owned(self) -> Shutdown {
+        self.shutdown_token
     }
 
     fn create_task(
@@ -147,7 +71,7 @@ impl AIProxyServer {
         stream: TcpStream,
         server_addr: SocketAddr,
         connected_client: ConnectedClient,
-    ) -> IoResult<AIProxyTask> {
+    ) -> IoResult<Self::Task> {
         let reader = BufReader::new(stream);
         // add client to client_handler
         Ok(AIProxyTask {
@@ -161,6 +85,56 @@ impl AIProxyServer {
             db_client: self.db_client.clone(),
         })
     }
+}
+
+impl AIProxyServer {
+    pub async fn new(config: AIProxyConfig) -> IoResult<Self> {
+        let shutdown_token = Shutdown::default();
+        Self::build(config, shutdown_token).await
+    }
+
+    pub async fn build(config: AIProxyConfig, shutdown_token: Shutdown) -> IoResult<Self> {
+        // Enable log and tracing
+        tracer::init_log_or_trace(
+            config.enable_tracing,
+            SERVICE_NAME,
+            &config.otel_endpoint,
+            &config.log_level,
+        );
+        let listener =
+            tokio::net::TcpListener::bind(format!("{}:{}", &config.host, &config.port)).await?;
+        let write_flag = Arc::new(AtomicBool::new(false));
+        let db_client = Self::build_db_client(&config).await;
+        let mut store_handler =
+            AIStoreHandler::new(write_flag.clone(), config.supported_models.clone());
+        if let Some(ref persist_location) = config.persist_location {
+            match Persistence::load_snapshot(persist_location) {
+                Err(e) => {
+                    log::error!("Failed to load snapshot from persist location {e}");
+                    if config.fail_on_startup_if_persist_load_fails {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            e.to_string(),
+                        ));
+                    }
+                }
+                Ok(snapshot) => {
+                    store_handler.use_snapshot(snapshot);
+                }
+            }
+        };
+        let client_handler = Arc::new(ClientHandler::new(config.maximum_clients));
+
+        Ok(Self {
+            listener,
+            shutdown_token,
+            client_handler,
+            store_handler: Arc::new(store_handler),
+            cancellation_token: CancellationToken::new(),
+            config,
+            db_client: Arc::new(db_client),
+        })
+    }
 
     async fn build_db_client(config: &AIProxyConfig) -> DbClient {
         let manager = DbConnManager::new(config.db_host.clone(), config.db_port);
@@ -170,10 +144,5 @@ impl AIProxyServer {
             .expect("Cannot establish connection to the Database");
 
         DbClient::new_with_pool(pool)
-    }
-
-    #[cfg(test)]
-    pub fn write_flag(&self) -> Arc<AtomicBool> {
-        self.store_handler.write_flag()
     }
 }

--- a/ahnlich/ai/src/server/task.rs
+++ b/ahnlich/ai/src/server/task.rs
@@ -1,8 +1,8 @@
 use crate::engine::ai::models::Model;
-use crate::server::handler::AI_ALLOCATOR;
 use ahnlich_client_rs::db::DbClient;
 use ahnlich_types::ai::{AIQuery, AIServerQuery, AIServerResponse, AIServerResult};
-use ahnlich_types::db::{ConnectedClient, ServerInfo, ServerResponse};
+use ahnlich_types::client::ConnectedClient;
+use ahnlich_types::db::{ServerInfo, ServerResponse};
 use ahnlich_types::keyval::{StoreInput, StoreValue};
 use ahnlich_types::metadata::MetadataValue;
 use ahnlich_types::predicate::{Predicate, PredicateCondition};
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
+use utils::allocator::GLOBAL_ALLOCATOR;
 use utils::client::ClientHandler;
 use utils::protocol::AhnlichProtocol;
 
@@ -20,7 +21,7 @@ use crate::error::AIProxyError;
 use crate::AHNLICH_AI_RESERVED_META_KEY;
 
 #[derive(Debug)]
-pub(super) struct AIProxyTask {
+pub struct AIProxyTask {
     pub(super) server_addr: SocketAddr,
     pub(super) reader: BufReader<TcpStream>,
     pub(super) client_handler: Arc<ClientHandler>,
@@ -390,8 +391,8 @@ impl AIProxyTask {
             address: format!("{}", self.server_addr),
             version: *VERSION,
             r#type: ahnlich_types::ServerType::AI,
-            limit: AI_ALLOCATOR.limit(),
-            remaining: AI_ALLOCATOR.remaining(),
+            limit: GLOBAL_ALLOCATOR.limit(),
+            remaining: GLOBAL_ALLOCATOR.remaining(),
         }
     }
 }

--- a/ahnlich/ai/src/tests/aiproxy_test.rs
+++ b/ahnlich/ai/src/tests/aiproxy_test.rs
@@ -11,6 +11,7 @@ use ahnlich_types::{
     predicate::{Predicate, PredicateCondition},
     similarity::Algorithm,
 };
+use utils::server::AhnlichServerUtils;
 
 use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;

--- a/ahnlich/client/Cargo.toml
+++ b/ahnlich/client/Cargo.toml
@@ -27,3 +27,4 @@ db = { path = "../db", version = "*" }
 ai = { path = "../ai", version = "*" }
 pretty_assertions.workspace = true
 ndarray.workspace = true
+utils = { path = "../utils", version = "*" }

--- a/ahnlich/client/src/ai.rs
+++ b/ahnlich/client/src/ai.rs
@@ -401,6 +401,7 @@ mod tests {
     use std::collections::HashMap;
     use std::net::SocketAddr;
     use tokio::time::Duration;
+    use utils::server::AhnlichServerUtils;
 
     static CONFIG: Lazy<ServerConfig> = Lazy::new(|| ServerConfig::default());
     static AI_CONFIG: Lazy<AIProxyConfig> = Lazy::new(|| {

--- a/ahnlich/client/src/db.rs
+++ b/ahnlich/client/src/db.rs
@@ -442,6 +442,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
     use tokio::time::Duration;
+    use utils::server::AhnlichServerUtils;
 
     static CONFIG: Lazy<ServerConfig> = Lazy::new(|| ServerConfig::default().os_select_port());
 

--- a/ahnlich/db/Cargo.toml
+++ b/ahnlich/db/Cargo.toml
@@ -29,13 +29,14 @@ ahnlich_types = { path = "../types", version = "*" }
 ahnlich_similarity = { path = "../similarity", version = "*", features = ["serde"] }
 tokio.workspace = true
 tokio-graceful.workspace = true
-cap.workspace = true
+tokio-util.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
 tracer = { path = "../tracer", version = "*" }
 serde_json.workspace = true
 async-trait.workspace = true
 rayon.workspace = true
+log.workspace = true
 
 
 [dev-dependencies]

--- a/ahnlich/db/src/cli/server.rs
+++ b/ahnlich/db/src/cli/server.rs
@@ -28,6 +28,9 @@ pub struct ServerConfig {
     /// persistence location
     #[arg(long, requires_if("true", "enable_persistence"))]
     pub(crate) persist_location: Option<std::path::PathBuf>,
+    /// Controls whether we crash or not on startup if persisting load fails
+    #[arg(long, default_value_t = false, action=ArgAction::SetFalse)]
+    pub(crate) fail_on_startup_if_persist_load_fails: bool,
 
     /// persistence interval in milliseconds
     /// A new persistence round would be scheduled for persistence_interval into the future after
@@ -68,6 +71,7 @@ impl Default for ServerConfig {
             port: 1369,
             enable_persistence: false,
             persist_location: None,
+            fail_on_startup_if_persist_load_fails: false,
             persistence_interval: 1000 * 60 * 5,
             allocator_size: 1_073_741_824,
             message_size: 1_048_576,

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -24,7 +24,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use utils::server::AhnlichPersistenceUtils;
+use utils::persistence::AhnlichPersistenceUtils;
 /// A hash of Store key, this is more preferable when passing around references as arrays can be
 /// potentially larger
 /// We should be only able to generate a store key id from a 1D vector except during tests

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -24,6 +24,7 @@ use std::num::NonZeroUsize;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use utils::server::AhnlichPersistenceUtils;
 /// A hash of Store key, this is more preferable when passing around references as arrays can be
 /// potentially larger
 /// We should be only able to generate a store key id from a 1D vector except during tests
@@ -65,6 +66,20 @@ pub struct StoreHandler {
     /// Making use of a concurrent hashmap, we should be able to create an engine that manages stores
     stores: Stores,
     pub write_flag: Arc<AtomicBool>,
+}
+
+impl AhnlichPersistenceUtils for StoreHandler {
+    type PersistenceObject = Stores;
+
+    #[tracing::instrument(skip_all)]
+    fn write_flag(&self) -> Arc<AtomicBool> {
+        self.write_flag.clone()
+    }
+
+    #[tracing::instrument(skip(self))]
+    fn get_snapshot(&self) -> Self::PersistenceObject {
+        self.stores.clone()
+    }
 }
 
 pub type Stores = Arc<ConcurrentHashMap<StoreName, Arc<Store>>>;

--- a/ahnlich/db/src/main.rs
+++ b/ahnlich/db/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 
 use std::error::Error;
+use utils::server::AhnlichServerUtils;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/ahnlich/db/src/server/handler.rs
+++ b/ahnlich/db/src/server/handler.rs
@@ -15,7 +15,7 @@ use utils::server::AhnlichServerUtils;
 use utils::server::ServerUtilsConfig;
 use utils::{client::ClientHandler, persistence::Persistence};
 
-const SERVICE_NAME: &'static str = "ahnlich-db";
+const SERVICE_NAME: &str = "ahnlich-db";
 
 pub struct Server<'a> {
     listener: TcpListener,

--- a/ahnlich/db/src/server/handler.rs
+++ b/ahnlich/db/src/server/handler.rs
@@ -1,155 +1,66 @@
 use super::task::ServerTask;
 use crate::cli::ServerConfig;
 use crate::engine::store::StoreHandler;
-use ahnlich_types::db::ConnectedClient;
-use cap::Cap;
-use std::alloc;
+use ahnlich_types::client::ConnectedClient;
 use std::io::Result as IoResult;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::io::BufReader;
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
-use tokio::select;
 use tokio_graceful::Shutdown;
-use tracing::Instrument;
-use utils::{client::ClientHandler, persistence::Persistence, protocol::AhnlichProtocol};
+use tokio_util::sync::CancellationToken;
+use utils::server::AhnlichServerUtils;
+use utils::server::ServerUtilsConfig;
+use utils::{client::ClientHandler, persistence::Persistence};
 
-#[global_allocator]
-pub(super) static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());
+const SERVICE_NAME: &'static str = "ahnlich-db";
 
 pub struct Server<'a> {
     listener: TcpListener,
     shutdown_token: Shutdown,
     store_handler: Arc<StoreHandler>,
+    cancellation_token: CancellationToken,
     client_handler: Arc<ClientHandler>,
     config: &'a ServerConfig,
 }
 
-impl<'a> Server<'a> {
-    /// creates a server while injecting a shutdown_token
-    pub async fn new_with_shutdown(
-        config: &'a ServerConfig,
-        shutdown_token: Shutdown,
-    ) -> IoResult<Self> {
-        ALLOCATOR
-            .set_limit(config.allocator_size)
-            .expect("Could not set up server with allocator_size");
-        let listener =
-            tokio::net::TcpListener::bind(format!("{}:{}", &config.host, &config.port)).await?;
-        // Enable tracing
-        if config.enable_tracing {
-            let otel_url = config
-                .otel_endpoint
-                .to_owned()
-                .unwrap_or("http://127.0.0.1:4317".to_string());
-            tracer::init_tracing("ahnlich-db", Some(&config.log_level), &otel_url)
-        }
-        let write_flag = Arc::new(AtomicBool::new(false));
-        let client_handler = Arc::new(ClientHandler::new(config.maximum_clients));
-        let mut store_handler = StoreHandler::new(write_flag.clone());
-        if let Some(persist_location) = &config.persist_location {
-            match Persistence::load_snapshot(persist_location) {
-                Err(e) => {
-                    tracing::error!("Failed to load snapshot from persist location {e}");
-                }
-                Ok(snapshot) => {
-                    store_handler.use_snapshot(snapshot);
-                }
-            }
-            // spawn the persistence task
-            let mut persistence_task = Persistence::task(
-                write_flag,
-                config.persistence_interval,
-                persist_location,
-                store_handler.get_stores(),
-            );
-            shutdown_token
-                .spawn_task_fn(|guard| async move { persistence_task.monitor(guard).await });
-        };
-        Ok(Self {
-            listener,
-            shutdown_token,
-            store_handler: Arc::new(store_handler),
-            client_handler,
-            config,
-        })
-    }
-    /// initializes a server using server configuration
-    pub async fn new(config: &'a ServerConfig) -> IoResult<Self> {
-        let shutdown_token = Shutdown::default();
-        Self::new_with_shutdown(config, shutdown_token).await
-    }
+impl<'a> AhnlichServerUtils for Server<'a> {
+    type Task = ServerTask;
+    type PersistenceTask = StoreHandler;
 
-    #[cfg(test)]
-    pub fn write_flag(&self) -> Arc<AtomicBool> {
-        self.store_handler.write_flag()
-    }
-
-    /// starts accepting connections using the listener and processing the incoming streams
-    ///
-    /// listens for a ctrl_c signals to cancel spawned tasks
-    pub async fn start(self) -> IoResult<()> {
-        let server_addr = self.local_addr()?;
-        loop {
-            let shutdown_guard = self.shutdown_token.guard();
-            select! {
-                _ = shutdown_guard.cancelled() => {
-                    // need to drop the shutdown guard used here else self.shutdown times out
-                    drop(shutdown_guard);
-                    self.shutdown().await;
-                    break Ok(());
-                }
-                Ok((stream, connect_addr)) = self.accept_connection() => {
-                    tracing::info!("Connecting to {}", connect_addr);
-                    //  - Spawn a tokio task to handle the command while holding on to a reference to self
-                    //  - Convert the incoming bincode in a chunked manner to a Vec<DBQuery>
-                    //  - Use store_handler to process the queries
-                    //  - Block new incoming connections on shutdown by no longer accepting and then
-                    //  cancelling existing ServerTask or forcing them to run to completion
-
-                    if let Some(connected_client) = self.client_handler.connect(stream.peer_addr()?) {
-                        let mut task = self.create_task(stream, server_addr, connected_client)?;
-                        shutdown_guard.spawn_task_fn(|guard| async move {
-                            if let Err(e) = task.process(guard).instrument(tracing::info_span!("server_task").or_current()).await {
-                                tracing::error!("Error handling connection: {}", e)
-                            };
-                        });
-                    }
-                }
-            }
+    fn config(&self) -> ServerUtilsConfig {
+        ServerUtilsConfig {
+            service_name: SERVICE_NAME,
+            persist_location: &self.config.persist_location,
+            persistence_interval: self.config.persistence_interval,
+            allocator_size: self.config.allocator_size,
         }
     }
 
-    /// stops all tasks and performs cleanup
-    pub async fn shutdown(self) {
-        // TODO: Add cleanup for instance persistence
-        // just cancelling the token alone does not give enough time for each task to shutdown,
-        // there must be other measures in place to ensure proper cleanup
-        if self
-            .shutdown_token
-            .shutdown_with_limit(Duration::from_secs(10))
-            .await
-            .is_err()
-        {
-            tracing::error!("SERVER: shutdown took longer than timeout");
-        }
+    fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancellation_token
     }
 
-    pub fn local_addr(&self) -> IoResult<SocketAddr> {
-        self.listener.local_addr()
+    fn listener(&self) -> &TcpListener {
+        &self.listener
     }
 
-    pub async fn accept_connection(&self) -> IoResult<(TcpStream, SocketAddr)> {
-        if !self.client_handler.is_maxed_out() {
-            return self.listener.accept().await;
-        }
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "maximum clients exhausted",
-        ))
+    fn client_handler(&self) -> &Arc<ClientHandler> {
+        &self.client_handler
+    }
+
+    fn store_handler(&self) -> &Arc<Self::PersistenceTask> {
+        &self.store_handler
+    }
+
+    fn shutdown_token(&self) -> &Shutdown {
+        &self.shutdown_token
+    }
+
+    fn shutdown_token_owned(self) -> Shutdown {
+        self.shutdown_token
     }
 
     fn create_task(
@@ -157,7 +68,7 @@ impl<'a> Server<'a> {
         stream: TcpStream,
         server_addr: SocketAddr,
         connected_client: ConnectedClient,
-    ) -> IoResult<ServerTask> {
+    ) -> IoResult<Self::Task> {
         let reader = BufReader::new(stream);
         // add client to client_handler
         Ok(ServerTask {
@@ -169,5 +80,55 @@ impl<'a> Server<'a> {
             client_handler: self.client_handler.clone(),
             store_handler: self.store_handler.clone(),
         })
+    }
+}
+
+impl<'a> Server<'a> {
+    /// creates a server while injecting a shutdown_token
+    pub async fn new_with_shutdown(
+        config: &'a ServerConfig,
+        shutdown_token: Shutdown,
+    ) -> IoResult<Self> {
+        let listener =
+            tokio::net::TcpListener::bind(format!("{}:{}", &config.host, &config.port)).await?;
+        let write_flag = Arc::new(AtomicBool::new(false));
+        let client_handler = Arc::new(ClientHandler::new(config.maximum_clients));
+        let mut store_handler = StoreHandler::new(write_flag.clone());
+        if let Some(persist_location) = &config.persist_location {
+            match Persistence::load_snapshot(persist_location) {
+                Err(e) => {
+                    log::error!("Failed to load snapshot from persist location {e}");
+                    if config.fail_on_startup_if_persist_load_fails {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            e.to_string(),
+                        ));
+                    }
+                }
+                Ok(snapshot) => {
+                    store_handler.use_snapshot(snapshot);
+                }
+            }
+        };
+        Ok(Self {
+            listener,
+            shutdown_token,
+            store_handler: Arc::new(store_handler),
+            client_handler,
+            cancellation_token: CancellationToken::new(),
+            config,
+        })
+    }
+    /// initializes a server using server configuration
+    pub async fn new(config: &'a ServerConfig) -> IoResult<Self> {
+        let shutdown_token = Shutdown::default();
+        // Enable log and tracing
+        tracer::init_log_or_trace(
+            config.enable_tracing,
+            SERVICE_NAME,
+            &config.otel_endpoint,
+            &config.log_level,
+        );
+        Self::new_with_shutdown(config, shutdown_token).await
     }
 }

--- a/ahnlich/db/src/server/task.rs
+++ b/ahnlich/db/src/server/task.rs
@@ -1,18 +1,17 @@
 use crate::engine::store::StoreHandler;
-use crate::server::handler::ALLOCATOR;
-use ahnlich_types::db::{
-    ConnectedClient, DBQuery, ServerDBQuery, ServerInfo, ServerResponse, ServerResult,
-};
+use ahnlich_types::client::ConnectedClient;
+use ahnlich_types::db::{DBQuery, ServerDBQuery, ServerInfo, ServerResponse, ServerResult};
 use ahnlich_types::version::VERSION;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
+use utils::allocator::GLOBAL_ALLOCATOR;
 use utils::client::ClientHandler;
 use utils::protocol::AhnlichProtocol;
 
 #[derive(Debug)]
-pub(super) struct ServerTask {
+pub struct ServerTask {
     pub(super) server_addr: SocketAddr,
     pub(super) reader: BufReader<TcpStream>,
     pub(super) store_handler: Arc<StoreHandler>,
@@ -159,8 +158,8 @@ impl ServerTask {
             address: format!("{}", self.server_addr),
             version: *VERSION,
             r#type: ahnlich_types::ServerType::Database,
-            limit: ALLOCATOR.limit(),
-            remaining: ALLOCATOR.remaining(),
+            limit: GLOBAL_ALLOCATOR.limit(),
+            remaining: GLOBAL_ALLOCATOR.remaining(),
         }
     }
 }

--- a/ahnlich/tracer/Cargo.toml
+++ b/ahnlich/tracer/Cargo.toml
@@ -10,3 +10,8 @@ tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp = "0.16.0"
 opentelemetry_sdk = { version = "0.23.0", features = [ "rt-tokio", "rt-tokio-current-thread"]}
+log.workspace = true
+# Builds filters given to us to ensure granular logging
+env_logger = "0.10"
+# Connects log to tracing allowing us to always use log everywhere and still appear within traces
+tracing-log = "0.1"

--- a/ahnlich/typegen/src/tracers/server_response/ai.rs
+++ b/ahnlich/typegen/src/tracers/server_response/ai.rs
@@ -3,7 +3,8 @@ use ahnlich_types::keyval::StoreInput;
 use ahnlich_types::similarity::Similarity;
 use ahnlich_types::{
     ai::{AIModel, AIServerResponse, AIServerResult, AIStoreInfo},
-    db::{ConnectedClient, ServerInfo, StoreUpsert},
+    client::ConnectedClient,
+    db::{ServerInfo, StoreUpsert},
     keyval::StoreName,
     metadata::{MetadataKey, MetadataValue},
     version::Version,

--- a/ahnlich/typegen/src/tracers/server_response/db.rs
+++ b/ahnlich/typegen/src/tracers/server_response/db.rs
@@ -1,6 +1,7 @@
 use ahnlich_types::similarity::Similarity;
 use ahnlich_types::{
-    db::{ConnectedClient, ServerInfo, ServerResponse, ServerResult, StoreInfo, StoreUpsert},
+    client::ConnectedClient,
+    db::{ServerInfo, ServerResponse, ServerResult, StoreInfo, StoreUpsert},
     keyval::{StoreKey, StoreName},
     metadata::{MetadataKey, MetadataValue},
     version::Version,

--- a/ahnlich/types/src/ai/server.rs
+++ b/ahnlich/types/src/ai/server.rs
@@ -1,6 +1,7 @@
 use super::AIModel;
 use crate::bincode::{BinCodeSerAndDeser, BinCodeSerAndDeserResponse};
-use crate::db::{ConnectedClient, ServerInfo, StoreUpsert};
+use crate::client::ConnectedClient;
+use crate::db::{ServerInfo, StoreUpsert};
 use crate::keyval::StoreInput;
 use crate::keyval::StoreName;
 use crate::keyval::StoreValue;

--- a/ahnlich/types/src/client.rs
+++ b/ahnlich/types/src/client.rs
@@ -1,0 +1,30 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialOrd, Ord)]
+pub struct ConnectedClient {
+    pub address: String,
+    // NOTE: We are using System specific time so the time marked by clients cannot be relied on to
+    // be monotonic and the size depends on operating system
+    pub time_connected: SystemTime,
+}
+
+// NOTE: ConnectedClient should be unique purely by address assuming we are not doing any TCP magic
+// to allow port reuse
+impl Hash for ConnectedClient {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.address.hash(state)
+    }
+}
+
+impl PartialEq for ConnectedClient {
+    fn eq(&self, other: &Self) -> bool {
+        self.address.eq(&other.address)
+    }
+}

--- a/ahnlich/types/src/db/mod.rs
+++ b/ahnlich/types/src/db/mod.rs
@@ -2,6 +2,4 @@ mod query;
 mod server;
 
 pub use query::{Query as DBQuery, ServerQuery as ServerDBQuery};
-pub use server::{
-    ConnectedClient, ServerInfo, ServerResponse, ServerResult, StoreInfo, StoreUpsert,
-};
+pub use server::{ServerInfo, ServerResponse, ServerResult, StoreInfo, StoreUpsert};

--- a/ahnlich/types/src/db/server.rs
+++ b/ahnlich/types/src/db/server.rs
@@ -1,4 +1,5 @@
 use crate::bincode::{BinCodeSerAndDeser, BinCodeSerAndDeserResponse};
+use crate::client::ConnectedClient;
 use crate::keyval::StoreKey;
 use crate::keyval::StoreName;
 use crate::keyval::StoreValue;
@@ -9,8 +10,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::hash::Hash;
-use std::hash::Hasher;
-use std::time::SystemTime;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ServerResponse {
@@ -72,30 +71,6 @@ impl PartialEq for ServerInfo {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialOrd, Ord)]
-pub struct ConnectedClient {
-    pub address: String,
-    // NOTE: We are using System specific time so the time marked by clients cannot be relied on to
-    // be monotonic and the size depends on operating system
-    pub time_connected: SystemTime,
-}
-
-// NOTE: ConnectedClient should be unique purely by address assuming we are not doing any TCP magic
-// to allow port reuse
-impl Hash for ConnectedClient {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        self.address.hash(state)
-    }
-}
-
-impl PartialEq for ConnectedClient {
-    fn eq(&self, other: &Self) -> bool {
-        self.address.eq(&other.address)
-    }
-}
 pub type ServerResultInner = Vec<Result<ServerResponse, String>>;
 // ServerResult: Given that an array of queries are sent in, we expect that an array of responses
 // be returned each being a potential error

--- a/ahnlich/types/src/lib.rs
+++ b/ahnlich/types/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ai;
 pub mod bincode;
+pub mod client;
 pub mod db;
 pub mod keyval;
 pub mod metadata;

--- a/ahnlich/utils/Cargo.toml
+++ b/ahnlich/utils/Cargo.toml
@@ -17,3 +17,6 @@ async-trait.workspace = true
 tempfile = "3.5"
 tokio-graceful.workspace = true
 serde_json.workspace = true
+log.workspace = true
+cap = "0.1.2"
+tokio-util.workspace = true

--- a/ahnlich/utils/src/allocator.rs
+++ b/ahnlich/utils/src/allocator.rs
@@ -1,0 +1,5 @@
+use cap::Cap;
+use std::alloc;
+
+#[global_allocator]
+pub static GLOBAL_ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::max_value());

--- a/ahnlich/utils/src/client.rs
+++ b/ahnlich/utils/src/client.rs
@@ -1,4 +1,4 @@
-use ahnlich_types::db::ConnectedClient;
+use ahnlich_types::client::ConnectedClient;
 use flurry::HashSet as ConcurrentHashSet;
 use std::collections::HashSet as StdHashSet;
 use std::net::SocketAddr;
@@ -23,8 +23,9 @@ impl ClientHandler {
     #[tracing::instrument(skip(self))]
     pub fn connect(&self, addr: SocketAddr) -> Option<ConnectedClient> {
         let pinned = self.clients.pin();
+        log::debug!("Current client len {}", pinned.len());
         if self.is_maxed_out() {
-            tracing::error!(
+            log::error!(
                 "Maximum clients count {} reached or exceeded with {}",
                 pinned.len(),
                 self.maximum_clients

--- a/ahnlich/utils/src/lib.rs
+++ b/ahnlich/utils/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod allocator;
 pub mod client;
 pub mod persistence;
 pub mod protocol;
+pub mod server;

--- a/ahnlich/utils/src/persistence.rs
+++ b/ahnlich/utils/src/persistence.rs
@@ -14,6 +14,20 @@ use tokio::time::sleep;
 use tokio::time::Duration;
 use tokio_graceful::ShutdownGuard;
 
+pub trait AhnlichPersistenceUtils {
+    type PersistenceObject: Serialize + DeserializeOwned + Send + Sync + 'static;
+
+    fn write_flag(&self) -> Arc<AtomicBool>;
+
+    // TODO: We can in theory make loading of snapshot possible across threads but it is annoying
+    // and not completely necessary(?) to have to lock and unlock a primitive to be able to modify
+    // simply to load snapshot at the start
+
+    //    fn use_snapshot(&self, object: Self::PersistenceObject);
+
+    fn get_snapshot(&self) -> Self::PersistenceObject;
+}
+
 #[derive(Error, Debug)]
 pub enum PersistenceTaskError {
     #[error("Error with file {0}")]

--- a/ahnlich/utils/src/persistence.rs
+++ b/ahnlich/utils/src/persistence.rs
@@ -62,35 +62,37 @@ impl<T: Serialize + DeserializeOwned> Persistence<T> {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn monitor(&mut self, shutdown_guard: ShutdownGuard) {
+    pub async fn monitor(&self, shutdown_guard: ShutdownGuard) {
         loop {
             select! {
                 _  = shutdown_guard.cancelled() => {
+                    log::debug!("Shutting down persistence thread");
                     break;
                 }
                 has_potential_write = self.has_potential_write() => {
+                    log::debug!("In potential write");
                     if has_potential_write {
                         let persist_location: &Path = self.persist_location.as_ref();
                         let writer = if let Ok(file) = NamedTempFile::new_in(persist_location.parent().expect("Could not get parent directory of persist location")) {
                             file
                         } else {
-                            tracing::error!("Could not create persistence file, skipping");
+                            log::error!("Could not create persistence file, skipping");
                             continue;
                         };
                         let temp_path = writer.path();
                         // set write flag to false before writing to it
                         let _ = self.write_flag.compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst);
                         if let Err(e) = serde_json::to_writer(&writer, &self.persist_object) {
-                            tracing::error!("Error writing stores to temp file {e}");
+                            log::error!("Error writing stores to temp file {e}");
 
                         } else {
                             match std::fs::rename(temp_path, persist_location) {
-                                Ok(_) => tracing::debug!("Persisted stores to disk"),
-                                Err(e) => tracing::error!("Error writing temp file to persist location {e}"),
+                                Ok(_) => log::debug!("Persisted stores to disk"),
+                                Err(e) => log::error!("Error writing temp file to persist location {e}"),
                             };
                         }
                     } else {
-                        tracing::debug!("No potential writes happened during persistence interval")
+                        log::debug!("No potential writes happened during persistence interval")
                     }
                 }
             }

--- a/ahnlich/utils/src/server.rs
+++ b/ahnlich/utils/src/server.rs
@@ -1,0 +1,160 @@
+use crate::allocator::GLOBAL_ALLOCATOR;
+use crate::client::ClientHandler;
+use crate::persistence::Persistence;
+use crate::protocol::AhnlichProtocol;
+use ahnlich_types::client::ConnectedClient;
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+use std::{io::Result as IoResult, sync::Arc};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::select;
+use tokio_graceful::Shutdown;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+
+pub trait AhnlichPersistenceUtils {
+    type PersistenceObject: Serialize + DeserializeOwned + Send + Sync + 'static;
+
+    fn write_flag(&self) -> Arc<AtomicBool>;
+
+    // TODO: We can in theory make loading of snapshot possible across threads but it is annoying
+    // and not completely necessary(?) to have to lock and unlock a primitive to be able to modify
+    // simply to load snapshot at the start
+
+    //    fn use_snapshot(&self, object: Self::PersistenceObject);
+
+    fn get_snapshot(&self) -> Self::PersistenceObject;
+}
+
+#[derive(Debug)]
+pub struct ServerUtilsConfig<'a> {
+    pub service_name: &'static str,
+    // persistence stuff
+    pub persistence_interval: u64,
+    pub persist_location: &'a Option<std::path::PathBuf>,
+    // global allocator
+    pub allocator_size: usize,
+}
+
+#[async_trait]
+pub trait AhnlichServerUtils: Sized {
+    type Task: AhnlichProtocol + Send + Sync + 'static;
+    type PersistenceTask: AhnlichPersistenceUtils;
+
+    fn config(&self) -> ServerUtilsConfig;
+
+    fn listener(&self) -> &TcpListener;
+    fn client_handler(&self) -> &Arc<ClientHandler>;
+    fn store_handler(&self) -> &Arc<Self::PersistenceTask>;
+    fn write_flag(&self) -> Arc<AtomicBool> {
+        self.store_handler().write_flag()
+    }
+
+    fn create_task(
+        &self,
+        stream: TcpStream,
+        server_addr: SocketAddr,
+        connected_client: ConnectedClient,
+    ) -> IoResult<Self::Task>;
+
+    fn local_addr(&self) -> IoResult<SocketAddr> {
+        self.listener().local_addr()
+    }
+
+    fn shutdown_token(&self) -> &Shutdown;
+    fn shutdown_token_owned(self) -> Shutdown;
+
+    fn cancellation_token(&self) -> &CancellationToken;
+
+    /// stops all tasks and performs cleanup
+    async fn shutdown(self) {
+        let service_name = self.config().service_name;
+        // TODO: Add cleanup for instance persistence
+        // just cancelling the token alone does not give enough time for each task to shutdown,
+        // there must be other measures in place to ensure proper cleanup
+        if self
+            .shutdown_token_owned()
+            .shutdown_with_limit(Duration::from_secs(10))
+            .await
+            .is_err()
+        {
+            log::error!("{}: shutdown took longer than timeout", service_name);
+        };
+        tracer::shutdown_tracing();
+    }
+
+    /// Runs through several processes to start up the server
+    /// - Sets global allocator cap
+    /// - Spawns Persistence listeneer thread
+    /// - Accepts incoming connections to the listener and processes streams
+    /// - Listens for ctrl_c signal to trigger spawned tasks cancellation
+    /// - Cancellation triggers clean up of loggers and tracers
+    async fn start(self) -> IoResult<()> {
+        let service_name = self.config().service_name;
+        let global_allocator_cap = self.config().allocator_size;
+        GLOBAL_ALLOCATOR
+            .set_limit(global_allocator_cap)
+            .expect(&format!(
+                "Could not set up {service_name} with allocator_size"
+            ));
+
+        log::debug!("Set max size for global allocator to: {global_allocator_cap}");
+        let server_addr = self.local_addr()?;
+        if let Some(persist_location) = self.config().persist_location {
+            let persistence_task = Persistence::task(
+                self.write_flag(),
+                self.config().persistence_interval,
+                persist_location,
+                self.store_handler().get_snapshot(),
+            );
+            self.shutdown_token()
+                .spawn_task_fn(|guard| async move { persistence_task.monitor(guard).await });
+        };
+        loop {
+            let shutdown_guard = self.shutdown_token().guard();
+            select! {
+                // We use biased selection as it would order our futures according to physical
+                // arrangements below
+                // We want shutdown signals to alwyas be checked for first, hence the arrangements
+                biased;
+
+                // shutdown handler from Ctrl+C signals
+                _ = shutdown_guard.cancelled() => {
+                    // need to drop the shutdown guard used here else self.shutdown times out
+                    log::info!("Kill signal received for shutdown");
+                    drop(shutdown_guard);
+                    self.shutdown().await;
+                    break Ok(());
+                }
+                // shutdown handler from external cancellation tokens
+                _ = self.cancellation_token().cancelled() => {
+                    log::info!("External thread triggered cancellation token");
+                    drop(shutdown_guard);
+                    self.shutdown().await;
+                    break Ok(());
+                }
+                Ok((stream, connect_addr)) = self.listener().accept() => {
+                    //  - Spawn a tokio task to handle the command while holding on to a reference to self
+                    //  - Convert the incoming bincode in a chunked manner to a Vec<AIQuery>
+                    //  - Use store_handler to process the queries
+                    //  - Block new incoming connections on shutdown by no longer accepting and then
+                    //  cancelling existing ServerTask or forcing them to run to completion
+
+                    if let Some(connected_client) = self.client_handler().connect(stream.peer_addr()?) {
+                        log::info!("Connecting to {}", connect_addr);
+                        let mut task = self.create_task(stream, server_addr, connected_client)?;
+                        shutdown_guard.spawn_task_fn(|guard| async move {
+                            if let Err(e) = task.process(guard).instrument(tracing::info_span!("server_task").or_current()).await {
+                                log::error!("Error handling connection: {}", e)
+                            };
+                        });
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Multiple things done on this PR in typical hack fashion
- Unifying the logic for what constitutes an ahnlich server i.e introducing `utils::server::AhnlichServerUtils` and implementing it for both AI and DB servers
- Implementing `utils::persistence::AhnlichPersistenceUtils` for individual stores. This isn't perfect and I'd explain below why not
- The changes above helped standardize the logic for what we expect our servers to do, `utils::server::AhnlichServerUtils::start` is the entry point and does multiple things. One thing it doesn't do however is load previous snapshots from persistence. 
To do this we need `mut` references to the underlying store handler and we won't get that other than with turning the `Arc<T>` into `Arc<Mutex<T>`. `T` in question is thread-safe so there was never a need to `Mutex` it. However to unify the logic of where we load snapshots, it would work. Opted against this for now anyways as we only load once at the start of the binary and introducing a lock around a lockless data structure would be sad. So a bit of replication stays
- Tracing initialization also stays duplicated as some things happen during Server build just before `utils::server::AhnlichServerUtils::start` that we would want to show up on logs/traces.
- Fixed the error at the end of `Ctrl-C` shutdown. It stemmed from the tracing subscriber still looking for a runtime so `tracer::shutdown_tracing` works
- Removed the stupid json logger and opted for something much more sane with ansi coloring support
- Introduced `CancellationToken` to aid cancelling a server by cloning the token. This will be pretty amazing to use during tests to shutdown a server organically and test some things e.g pooling reconnection behaviour