### PR TITLE
Getting rid of tokio-graceful

### DIFF
--- a/ahnlich/Cargo.toml
+++ b/ahnlich/Cargo.toml
@@ -7,7 +7,7 @@ members = [
   "typegen",
   "utils",
   "similarity",
-  "ai",
+  "ai", "task-manager",
 ]
 resolver = "2"
 
@@ -34,7 +34,6 @@ tokio = { version = "1.37.0", features = [
   "sync",
   "signal"
 ]}
-tokio-graceful = "0.1.6"
 tokio-util = { version = "0.7.11", features = ["rt"] }
 rand = "0.8"
 rayon = "1.10"

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -25,8 +25,8 @@ clap.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
 utils = { path = "../utils", version = "*" }
+task-manager = { path = "../task-manager", version = "*" }
 ahnlich_types = { path = "../types", version = "*" }
-tokio-graceful.workspace = true
 tokio-util.workspace = true
 once_cell.workspace = true
 tracing.workspace = true

--- a/ahnlich/ai/src/main.rs
+++ b/ahnlich/ai/src/main.rs
@@ -9,6 +9,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     match cli.command {
         ahnlich_ai_proxy::cli::Commands::Run(config) => {
             let server = ahnlich_ai_proxy::server::handler::AIProxyServer::new(config).await?;
+            // TODO: Use server task manager here to spawn inference thread;
             server.start().await?;
         }
         ahnlich_ai_proxy::cli::Commands::SupportedModels(config) => config.output(),

--- a/ahnlich/ai/src/server/task.rs
+++ b/ahnlich/ai/src/server/task.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
+use tokio::sync::Mutex;
 use utils::allocator::GLOBAL_ALLOCATOR;
 use utils::client::ClientHandler;
 use utils::protocol::AhnlichProtocol;
@@ -23,7 +24,7 @@ use crate::AHNLICH_AI_RESERVED_META_KEY;
 #[derive(Debug)]
 pub struct AIProxyTask {
     pub(super) server_addr: SocketAddr,
-    pub(super) reader: BufReader<TcpStream>,
+    pub(super) reader: Arc<Mutex<BufReader<TcpStream>>>,
     pub(super) client_handler: Arc<ClientHandler>,
     pub(super) store_handler: Arc<AIStoreHandler>,
     pub(super) connected_client: ConnectedClient,
@@ -42,8 +43,8 @@ impl AhnlichProtocol for AIProxyTask {
     fn maximum_message_size(&self) -> u64 {
         self.maximum_message_size
     }
-    fn reader(&mut self) -> &mut BufReader<TcpStream> {
-        &mut self.reader
+    fn reader(&self) -> Arc<Mutex<BufReader<TcpStream>>> {
+        self.reader.clone()
     }
 
     async fn handle(&self, queries: Vec<AIQuery>) -> AIServerResult {

--- a/ahnlich/db/Cargo.toml
+++ b/ahnlich/db/Cargo.toml
@@ -26,9 +26,9 @@ clap.workspace = true
 thiserror.workspace = true
 utils = { path = "../utils", version = "*" }
 ahnlich_types = { path = "../types", version = "*" }
+task-manager = { path = "../task-manager", version = "*" }
 ahnlich_similarity = { path = "../similarity", version = "*", features = ["serde"] }
 tokio.workspace = true
-tokio-graceful.workspace = true
 tokio-util.workspace = true
 once_cell.workspace = true
 tracing.workspace = true

--- a/ahnlich/db/src/server/task.rs
+++ b/ahnlich/db/src/server/task.rs
@@ -6,6 +6,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
+use tokio::sync::Mutex;
 use utils::allocator::GLOBAL_ALLOCATOR;
 use utils::client::ClientHandler;
 use utils::protocol::AhnlichProtocol;
@@ -13,7 +14,7 @@ use utils::protocol::AhnlichProtocol;
 #[derive(Debug)]
 pub struct ServerTask {
     pub(super) server_addr: SocketAddr,
-    pub(super) reader: BufReader<TcpStream>,
+    pub(super) reader: Arc<Mutex<BufReader<TcpStream>>>,
     pub(super) store_handler: Arc<StoreHandler>,
     pub(super) client_handler: Arc<ClientHandler>,
     pub(super) connected_client: ConnectedClient,
@@ -31,8 +32,8 @@ impl AhnlichProtocol for ServerTask {
     fn maximum_message_size(&self) -> u64 {
         self.maximum_message_size
     }
-    fn reader(&mut self) -> &mut BufReader<TcpStream> {
-        &mut self.reader
+    fn reader(&self) -> Arc<Mutex<BufReader<TcpStream>>> {
+        self.reader.clone()
     }
 
     async fn handle(&self, queries: Vec<DBQuery>) -> ServerResult {

--- a/ahnlich/task-manager/Cargo.toml
+++ b/ahnlich/task-manager/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "task-manager"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio-util.workspace = true
+tokio.workspace = true
+log.workspace = true

--- a/ahnlich/task-manager/src/lib.rs
+++ b/ahnlich/task-manager/src/lib.rs
@@ -1,0 +1,140 @@
+use log::{debug, info};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::{select, signal};
+/// TaskManager is a struct to achieve multiple things
+///
+/// - Spawn multiple long running "tasks" that expect to be run in a loop
+/// - Break the task loop when one of the following happens:
+///     - SIGterm or SIGint is received
+///     - External cancellation token is triggered
+///     - Task chooses to end via some internal condition
+///
+/// TaskManager extends the tokio utils TaskTracker to ensure that ever task loop is being tracked
+/// and the tasks have the ability to perform any necessary cleanup before ending
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+pub struct CloneableAsyncClosure<F, Fut>
+where
+    F: Fn() -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = TaskLoopControl> + Send + 'static,
+{
+    inner: Arc<F>,
+    future: Pin<Box<Fut>>,
+}
+
+impl<F, Fut> CloneableAsyncClosure<F, Fut>
+where
+    F: Fn() -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = TaskLoopControl> + Send + 'static,
+{
+    pub fn new(f: F) -> Self {
+        let future = (f)();
+        CloneableAsyncClosure {
+            inner: Arc::new(f),
+            future: Box::pin(future),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.future = Box::pin((self.inner)());
+    }
+}
+
+impl<F, Fut> Future for CloneableAsyncClosure<F, Fut>
+where
+    F: Fn() -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = TaskLoopControl> + Send + 'static,
+{
+    type Output = TaskLoopControl;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.future.as_mut().poll(cx)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum TaskLoopControl {
+    Break,
+    Continue,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskManager {
+    cancellation_token: CancellationToken,
+    task_tracker: TaskTracker,
+}
+
+impl TaskManager {
+    pub fn new() -> Self {
+        Self {
+            cancellation_token: CancellationToken::new(),
+            task_tracker: TaskTracker::new(),
+        }
+    }
+
+    pub async fn spawn_task_loop<F>(&self, task: F, task_name: String)
+    where
+        F: Future<Output = TaskLoopControl> + Send + 'static,
+    {
+        let cancellation_token = self.cancellation_token.clone();
+        let task_name_copy = task_name.clone();
+        let mut task = Box::pin(task);
+
+        self.task_tracker.spawn(async move {
+            loop {
+                let loop_control = select! {
+                    // We use biased selection as it would order our futures according to physical
+                    // arrangements below
+                    // We want shutdown signals to always be checked for first, hence the arrangements
+                    biased;
+
+                    _ = signal::ctrl_c() => {
+                        info!("Received Ctrl-C signal, cancelling [{task_name}] task");
+                        TaskLoopControl::Break
+                    }
+                    _ = cancellation_token.cancelled() => {
+                        info!("Received Cancellation token signal, cancelling [{task_name}] task");
+                        TaskLoopControl::Break
+                    }
+                    result = &mut task => {
+                        result
+                    }
+                };
+                match loop_control {
+                    TaskLoopControl::Continue => {
+                        debug!("Continuing [{task_name}] task loop");
+                        continue;
+                    }
+                    TaskLoopControl::Break => {
+                        debug!("[{task_name}] Task cancelled");
+                        break;
+                    }
+                }
+            }
+        });
+
+        log::debug!("Spawned task {task_name_copy}",);
+    }
+
+    pub fn cancel_all(&self) {
+        self.cancellation_token.cancel()
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.clone()
+    }
+
+    pub async fn wait(&self) {
+        self.task_tracker.close();
+        self.task_tracker.wait().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/ahnlich/utils/Cargo.toml
+++ b/ahnlich/utils/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 ahnlich_types = { path = "../types", version = "*" }
+task-manager = { path = "../task-manager", version = "*" }
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
@@ -15,7 +16,6 @@ thiserror.workspace = true
 serde.workspace = true
 async-trait.workspace = true
 tempfile = "3.5"
-tokio-graceful.workspace = true
 serde_json.workspace = true
 log.workspace = true
 cap = "0.1.2"

--- a/ahnlich/utils/src/persistence.rs
+++ b/ahnlich/utils/src/persistence.rs
@@ -7,12 +7,11 @@ use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use task_manager::TaskLoopControl;
 use tempfile::NamedTempFile;
 use thiserror::Error;
-use tokio::select;
 use tokio::time::sleep;
 use tokio::time::Duration;
-use tokio_graceful::ShutdownGuard;
 
 pub trait AhnlichPersistenceUtils {
     type PersistenceObject: Serialize + DeserializeOwned + Send + Sync + 'static;
@@ -36,6 +35,7 @@ pub enum PersistenceTaskError {
     SerdeError(#[from] serde_json::error::Error),
 }
 
+#[derive(Debug, Clone)]
 pub struct Persistence<T> {
     write_flag: Arc<AtomicBool>,
     persistence_interval: u64,
@@ -76,40 +76,34 @@ impl<T: Serialize + DeserializeOwned> Persistence<T> {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn monitor(&self, shutdown_guard: ShutdownGuard) {
-        loop {
-            select! {
-                _  = shutdown_guard.cancelled() => {
-                    log::debug!("Shutting down persistence thread");
-                    break;
-                }
-                has_potential_write = self.has_potential_write() => {
-                    log::debug!("In potential write");
-                    if has_potential_write {
-                        let persist_location: &Path = self.persist_location.as_ref();
-                        let writer = if let Ok(file) = NamedTempFile::new_in(persist_location.parent().expect("Could not get parent directory of persist location")) {
-                            file
-                        } else {
-                            log::error!("Could not create persistence file, skipping");
-                            continue;
-                        };
-                        let temp_path = writer.path();
-                        // set write flag to false before writing to it
-                        let _ = self.write_flag.compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst);
-                        if let Err(e) = serde_json::to_writer(&writer, &self.persist_object) {
-                            log::error!("Error writing stores to temp file {e}");
-
-                        } else {
-                            match std::fs::rename(temp_path, persist_location) {
-                                Ok(_) => log::debug!("Persisted stores to disk"),
-                                Err(e) => log::error!("Error writing temp file to persist location {e}"),
-                            };
-                        }
-                    } else {
-                        log::debug!("No potential writes happened during persistence interval")
-                    }
-                }
+    pub async fn run(&self) -> TaskLoopControl {
+        if self.has_potential_write().await {
+            log::debug!("In potential write");
+            let persist_location: &Path = self.persist_location.as_ref();
+            let writer = if let Ok(file) = NamedTempFile::new_in(
+                persist_location
+                    .parent()
+                    .expect("Could not get parent directory of persist location"),
+            ) {
+                file
+            } else {
+                log::error!("Could not create persistence file, skipping");
+                return TaskLoopControl::Continue;
+            };
+            let temp_path = writer.path();
+            // set write flag to false before writing to it
+            let _ =
+                self.write_flag
+                    .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst);
+            if let Err(e) = serde_json::to_writer(&writer, &self.persist_object) {
+                log::error!("Error writing stores to temp file {e}");
+            } else {
+                match std::fs::rename(temp_path, persist_location) {
+                    Ok(_) => log::debug!("Persisted stores to disk"),
+                    Err(e) => log::error!("Error writing temp file to persist location {e}"),
+                };
             }
         }
+        TaskLoopControl::Continue
     }
 }

--- a/ahnlich/utils/src/protocol.rs
+++ b/ahnlich/utils/src/protocol.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 use std::io::Error;
 use std::io::ErrorKind;
 use std::sync::Arc;
-use task_manager::TaskLoopControl;
+use task_manager::TaskManagerGuard;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
@@ -21,8 +21,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 #[async_trait::async_trait]
 pub trait AhnlichProtocol
 where
-    Self::ServerQuery: BinCodeSerAndDeserQuery + Sized + Debug,
-    Self::ServerResponse: BinCodeSerAndDeserResponse + Sized + Debug,
+    Self::ServerQuery: BinCodeSerAndDeserQuery + Debug,
+    Self::ServerResponse: BinCodeSerAndDeserResponse + Debug,
 {
     type ServerQuery;
     type ServerResponse;
@@ -36,126 +36,135 @@ where
     }
 
     /// processes messages from a stream
-    async fn process(&mut self) -> TaskLoopControl {
+    async fn process(&self, shutdown_guard: TaskManagerGuard) {
         let mut magic_bytes_buf = [0u8; MAGIC_BYTES.len()];
         let mut version_buf = [0u8; VERSION_LENGTH];
         let mut length_buf = [0u8; LENGTH_HEADER_SIZE];
         let reader = self.reader();
         let mut reader = reader.lock().await;
+        loop {
+            tokio::select! {
+                biased;
 
-        match reader.read_exact(&mut magic_bytes_buf).await {
-            Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                let error = self.prefix_log("Hung up on buffered stream");
-                log::error!("{error}");
-                return TaskLoopControl::Break;
-            }
-            Err(e) => {
-                let error = self.prefix_log(format!("Error reading from task buffered stream {e}"));
-                log::error!("{error}");
-                return TaskLoopControl::Break;
-            }
-            Ok(_) => {
-                if magic_bytes_buf != MAGIC_BYTES {
-                    let error = "Invalid request stream".to_string();
-                    log::error!("{error}");
-                    return TaskLoopControl::Break;
+                _ = shutdown_guard.is_cancelled() => {
+                    break;
                 }
-                if let Err(e) = reader.read_exact(&mut version_buf).await {
-                    log::error!("{}", e.to_string());
-                    return TaskLoopControl::Break;
-                }
-                let version = match Version::deserialize_magic_bytes(&version_buf) {
-                    Ok(version) => version,
-                    Err(error) => {
-                        let error = format!("Unable to parse version chunk {error}");
-                        log::error!("{error}");
-                        return TaskLoopControl::Break;
-                    }
-                };
-                if !VERSION.is_compatible(&version) {
-                    let error = format!(
-                        "Incompatible versions, Server: {:?}, Client {version:?}",
-                        *VERSION
-                    );
-                    log::error!("{error}");
-                    return TaskLoopControl::Break;
-                }
-                // cap the message size to be of length 1MiB
-                if let Err(e) = reader.read_exact(&mut length_buf).await {
-                    let error = format!("Could not read length buffer {e}");
-                    log::error!("{error}");
-                    return TaskLoopControl::Break;
-                };
-                let data_length = u64::from_le_bytes(length_buf);
-                if data_length > self.maximum_message_size() {
-                    let error = self.prefix_log(format!(
-                        "Message cannot exceed {} bytes, configure `message_size` for higher",
-                        self.maximum_message_size()
-                    ));
-                    log::error!("{error}");
-                    return TaskLoopControl::Break;
-                }
-                let mut data = Vec::new();
-                if data.try_reserve(data_length as usize).is_err() {
-                    let error = self
-                        .prefix_log(format!("failed to reserve buffer of length {data_length}"));
-                    log::error!("{error}");
-                    return TaskLoopControl::Break;
-                };
-                data.resize(data_length as usize, 0u8);
-                if let Err(e) = reader.read_exact(&mut data).await {
-                    let error = format!("Could not read data buffer {e}");
-                    log::error!("{error}");
-                    return TaskLoopControl::Break;
-                };
-                match Self::ServerQuery::deserialize(&data) {
-                    Ok(queries) => {
-                        log::debug!("Got Queries {:?}", queries);
-                        let span = tracing::info_span!("query-processor");
-                        if let Some(trace_parent) = queries.get_traceparent() {
-                            let parent_context = match tracer::trace_parent_to_span(trace_parent)
-                                .map_err(|err| Error::new(ErrorKind::Other, err))
-                            {
-                                Ok(parent_context) => parent_context,
+                res = reader.read_exact(&mut magic_bytes_buf) => {
+                    match res {
+                        Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                            let error = self.prefix_log("Hung up on buffered stream");
+                            log::error!("{error}");
+                            break;
+                        }
+                        Err(e) => {
+                            let error = self.prefix_log(format!("Error reading from task buffered stream {e}"));
+                            log::error!("{error}");
+                            break
+                        }
+                        Ok(_) => {
+                            if magic_bytes_buf != MAGIC_BYTES {
+                                let error = "Invalid request stream".to_string();
+                                log::error!("{error}");
+                                break;
+                            }
+                            if let Err(e) = reader.read_exact(&mut version_buf).await {
+                                log::error!("{}", e.to_string());
+                                break;
+                            }
+                            let version = match Version::deserialize_magic_bytes(&version_buf) {
+                                Ok(version) => version,
                                 Err(error) => {
+                                    let error = format!("Unable to parse version chunk {error}");
                                     log::error!("{error}");
-                                    return TaskLoopControl::Break;
+                                    break;
                                 }
                             };
-                            span.set_parent(parent_context);
-                        }
-                        let results = self.handle(queries.into_inner()).instrument(span).await;
-                        if let Ok(binary_results) = results.serialize() {
-                            if let Err(error) = reader.get_mut().write_all(&binary_results).await {
+                            if !VERSION.is_compatible(&version) {
+                                let error = format!(
+                                    "Incompatible versions, Server: {:?}, Client {version:?}",
+                                    *VERSION
+                                );
                                 log::error!("{error}");
-                                return TaskLoopControl::Break;
+                                break;
+                            }
+                            // cap the message size to be of length 1MiB
+                            if let Err(e) = reader.read_exact(&mut length_buf).await {
+                                let error = format!("Could not read length buffer {e}");
+                                log::error!("{error}");
+                                break;
                             };
-                            log::debug!(
-                                "Sent Response of length {}, {:?}",
-                                binary_results.len(),
-                                binary_results
-                            );
+                            let data_length = u64::from_le_bytes(length_buf);
+                            if data_length > self.maximum_message_size() {
+                                let error = self.prefix_log(format!(
+                                        "Message cannot exceed {} bytes, configure `message_size` for higher",
+                                        self.maximum_message_size()
+                                ));
+                                log::error!("{error}");
+                                break;
+                            }
+                            let mut data = Vec::new();
+                            if data.try_reserve(data_length as usize).is_err() {
+                                let error = self
+                                    .prefix_log(format!("failed to reserve buffer of length {data_length}"));
+                                log::error!("{error}");
+                                break;
+                            };
+                            data.resize(data_length as usize, 0u8);
+                            if let Err(e) = reader.read_exact(&mut data).await {
+                                let error = format!("Could not read data buffer {e}");
+                                log::error!("{error}");
+                                break;
+                            };
+                            match Self::ServerQuery::deserialize(&data) {
+                                Ok(queries) => {
+                                    log::debug!("Got Queries {:?}", queries);
+                                    let span = tracing::info_span!("query-processor");
+                                    if let Some(trace_parent) = queries.get_traceparent() {
+                                        let parent_context = match tracer::trace_parent_to_span(trace_parent)
+                                            .map_err(|err| Error::new(ErrorKind::Other, err))
+                                            {
+                                                Ok(parent_context) => parent_context,
+                                                Err(error) => {
+                                                    log::error!("{error}");
+                                                    break;
+                                                }
+                                            };
+                                        span.set_parent(parent_context);
+                                    }
+                                    let results = self.handle(queries.into_inner()).instrument(span).await;
+                                    if let Ok(binary_results) = results.serialize() {
+                                        if let Err(error) = reader.get_mut().write_all(&binary_results).await {
+                                            log::error!("{error}");
+                                            break;
+                                        };
+                                        log::debug!(
+                                            "Sent Response of length {}, {:?}",
+                                            binary_results.len(),
+                                            binary_results
+                                        );
+                                    }
+                                }
+                                Err(error) => {
+                                    let error = self.prefix_log(&format!(
+                                            "Could not deserialize client message as server query {error}"
+                                    ));
+                                    log::error!("{error}");
+                                    let deserialize_error = Self::ServerResponse::from_error(
+                                        "Could not deserialize query, error is {e}".to_string(),
+                                    )
+                                        .serialize()
+                                        .expect("Could not serialize deserialize error");
+                                    if let Err(error) = reader.get_mut().write_all(&deserialize_error).await {
+                                        log::error!("{error}");
+                                        break;
+                                    };
+                                }
+                            }
                         }
-                    }
-                    Err(error) => {
-                        let error = self.prefix_log(&format!(
-                            "Could not deserialize client message as server query {error}"
-                        ));
-                        log::error!("{error}");
-                        let deserialize_error = Self::ServerResponse::from_error(
-                            "Could not deserialize query, error is {e}".to_string(),
-                        )
-                        .serialize()
-                        .expect("Could not serialize deserialize error");
-                        if let Err(error) = reader.get_mut().write_all(&deserialize_error).await {
-                            log::error!("{error}");
-                            return TaskLoopControl::Break;
-                        };
                     }
                 }
             }
         }
-        TaskLoopControl::Continue
     }
 
     async fn handle(

--- a/ahnlich/utils/src/protocol.rs
+++ b/ahnlich/utils/src/protocol.rs
@@ -10,11 +10,11 @@ use ahnlich_types::version::VERSION;
 use std::fmt::Debug;
 use std::io::Error;
 use std::io::ErrorKind;
-use std::io::Result as IoResult;
+use std::sync::Arc;
+use task_manager::TaskLoopControl;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
-use tokio::select;
-use tokio_graceful::ShutdownGuard;
+use tokio::sync::Mutex;
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -29,83 +29,133 @@ where
 
     fn connected_client(&self) -> &ConnectedClient;
     fn maximum_message_size(&self) -> u64;
-    fn reader(&mut self) -> &mut BufReader<TcpStream>;
+    fn reader(&self) -> Arc<Mutex<BufReader<TcpStream>>>;
 
     fn prefix_log(&self, message: impl std::fmt::Display) -> String {
         format!("ClIENT [{}]: {}", &self.connected_client().address, message)
     }
 
     /// processes messages from a stream
-    async fn process(&mut self, shutdown_guard: ShutdownGuard) -> IoResult<()> {
+    async fn process(&mut self) -> TaskLoopControl {
         let mut magic_bytes_buf = [0u8; MAGIC_BYTES.len()];
         let mut version_buf = [0u8; VERSION_LENGTH];
         let mut length_buf = [0u8; LENGTH_HEADER_SIZE];
+        let reader = self.reader();
+        let mut reader = reader.lock().await;
 
-        loop {
-            select! {
-                _ = shutdown_guard.cancelled() => {
-                    log::debug!("{}", self.prefix_log("Cancelling stream as server is shutting down"));
-                    break;
+        match reader.read_exact(&mut magic_bytes_buf).await {
+            Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                let error = self.prefix_log("Hung up on buffered stream");
+                log::error!("{error}");
+                return TaskLoopControl::Break;
+            }
+            Err(e) => {
+                let error = self.prefix_log(format!("Error reading from task buffered stream {e}"));
+                log::error!("{error}");
+                return TaskLoopControl::Break;
+            }
+            Ok(_) => {
+                if magic_bytes_buf != MAGIC_BYTES {
+                    let error = "Invalid request stream".to_string();
+                    log::error!("{error}");
+                    return TaskLoopControl::Break;
                 }
-                res = self.reader().read_exact(&mut magic_bytes_buf) => {
-                    match res {
-                        // reader was closed
-                        Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                            log::debug!("{}", self.prefix_log("Hung up on buffered stream"));
-                            break;
-                        }
-                        Err(e) => {
-                            log::error!("{}", self.prefix_log(format!("Error reading from task buffered stream {e}")));
-                        }
-                        Ok(_) => {
-                            if magic_bytes_buf != MAGIC_BYTES {
-                                return Err(Error::other("Invalid request stream"));
-                            }
-                            self.reader().read_exact(&mut version_buf).await?;
-                            let version = Version::deserialize_magic_bytes(&version_buf).map_err(|a| Error::other(format!("Unable to parse version chunk {a}")))?;
-                            if !VERSION.is_compatible(&version) {
-                                return Err(Error::other(format!("Incompatible versions, Server: {:?}, Client {version:?}", *VERSION)));
-                            }
-                            // cap the message size to be of length 1MiB
-                            self.reader().read_exact(&mut length_buf).await?;
-                            let data_length = u64::from_le_bytes(length_buf);
-                            if data_length > self.maximum_message_size() {
-                                log::error!("{}", self.prefix_log(format!("Message cannot exceed {} bytes, configure `message_size` for higher", self.maximum_message_size())));
-                                break
-                            }
-                            let mut data = Vec::new();
-                            if data.try_reserve(data_length as usize).is_err() {
-                                log::error!("{}", self.prefix_log(format!("Failed to reserve buffer of length {data_length}")));
-                                break
+                if let Err(e) = reader.read_exact(&mut version_buf).await {
+                    log::error!("{}", e.to_string());
+                    return TaskLoopControl::Break;
+                }
+                let version = match Version::deserialize_magic_bytes(&version_buf) {
+                    Ok(version) => version,
+                    Err(error) => {
+                        let error = format!("Unable to parse version chunk {error}");
+                        log::error!("{error}");
+                        return TaskLoopControl::Break;
+                    }
+                };
+                if !VERSION.is_compatible(&version) {
+                    let error = format!(
+                        "Incompatible versions, Server: {:?}, Client {version:?}",
+                        *VERSION
+                    );
+                    log::error!("{error}");
+                    return TaskLoopControl::Break;
+                }
+                // cap the message size to be of length 1MiB
+                if let Err(e) = reader.read_exact(&mut length_buf).await {
+                    let error = format!("Could not read length buffer {e}");
+                    log::error!("{error}");
+                    return TaskLoopControl::Break;
+                };
+                let data_length = u64::from_le_bytes(length_buf);
+                if data_length > self.maximum_message_size() {
+                    let error = self.prefix_log(format!(
+                        "Message cannot exceed {} bytes, configure `message_size` for higher",
+                        self.maximum_message_size()
+                    ));
+                    log::error!("{error}");
+                    return TaskLoopControl::Break;
+                }
+                let mut data = Vec::new();
+                if data.try_reserve(data_length as usize).is_err() {
+                    let error = self
+                        .prefix_log(format!("failed to reserve buffer of length {data_length}"));
+                    log::error!("{error}");
+                    return TaskLoopControl::Break;
+                };
+                data.resize(data_length as usize, 0u8);
+                if let Err(e) = reader.read_exact(&mut data).await {
+                    let error = format!("Could not read data buffer {e}");
+                    log::error!("{error}");
+                    return TaskLoopControl::Break;
+                };
+                match Self::ServerQuery::deserialize(&data) {
+                    Ok(queries) => {
+                        log::debug!("Got Queries {:?}", queries);
+                        let span = tracing::info_span!("query-processor");
+                        if let Some(trace_parent) = queries.get_traceparent() {
+                            let parent_context = match tracer::trace_parent_to_span(trace_parent)
+                                .map_err(|err| Error::new(ErrorKind::Other, err))
+                            {
+                                Ok(parent_context) => parent_context,
+                                Err(error) => {
+                                    log::error!("{error}");
+                                    return TaskLoopControl::Break;
+                                }
                             };
-                            data.resize(data_length as usize, 0u8);
-                            self.reader().read_exact(&mut data).await?;
-                            match Self::ServerQuery::deserialize(&data) {
-                                Ok(queries) => {
-                                log::debug!("Got Queries {:?}", queries);
-                                let span = tracing::info_span!("query-processor");
-                                if let Some(trace_parent) = queries.get_traceparent() {
-                                    let parent_context = tracer::trace_parent_to_span(trace_parent).map_err(|err|Error::new(ErrorKind::Other, err))?;
-                                    span.set_parent(parent_context);
-                                }
-                                let results = self.handle(queries.into_inner()).instrument(span).await;
-                                if let Ok(binary_results) = results.serialize() {
-                                    self.reader().get_mut().write_all(&binary_results).await?;
-                                    log::debug!("Sent Response of length {}, {:?}", binary_results.len(), binary_results);
-                                }
-                            },
-                            Err(e) =>{
-                                log::error!("{} {e}", self.prefix_log("Could not deserialize client message as server query"));
-                                let deserialize_error = Self::ServerResponse::from_error("Could not deserialize query, error is {e}".to_string()).serialize().expect("Could not serialize deserialize error");
-                                self.reader().get_mut().write_all(&deserialize_error).await?;
-                            }
+                            span.set_parent(parent_context);
+                        }
+                        let results = self.handle(queries.into_inner()).instrument(span).await;
+                        if let Ok(binary_results) = results.serialize() {
+                            if let Err(error) = reader.get_mut().write_all(&binary_results).await {
+                                log::error!("{error}");
+                                return TaskLoopControl::Break;
+                            };
+                            log::debug!(
+                                "Sent Response of length {}, {:?}",
+                                binary_results.len(),
+                                binary_results
+                            );
                         }
                     }
+                    Err(error) => {
+                        let error = self.prefix_log(&format!(
+                            "Could not deserialize client message as server query {error}"
+                        ));
+                        log::error!("{error}");
+                        let deserialize_error = Self::ServerResponse::from_error(
+                            "Could not deserialize query, error is {e}".to_string(),
+                        )
+                        .serialize()
+                        .expect("Could not serialize deserialize error");
+                        if let Err(error) = reader.get_mut().write_all(&deserialize_error).await {
+                            log::error!("{error}");
+                            return TaskLoopControl::Break;
+                        };
                     }
                 }
             }
         }
-        Ok(())
+        TaskLoopControl::Continue
     }
 
     async fn handle(

--- a/ahnlich/utils/src/server.rs
+++ b/ahnlich/utils/src/server.rs
@@ -7,11 +7,11 @@ use ahnlich_types::client::ConnectedClient;
 use async_trait::async_trait;
 use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
-use std::time::Duration;
 use std::{io::Result as IoResult, sync::Arc};
+use task_manager::CloneableAsyncClosure;
+use task_manager::TaskLoopControl;
+use task_manager::TaskManager;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::select;
-use tokio_graceful::Shutdown;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
@@ -26,7 +26,7 @@ pub struct ServerUtilsConfig<'a> {
 }
 
 #[async_trait]
-pub trait AhnlichServerUtils: Sized {
+pub trait AhnlichServerUtils: Sized + Send + Sync + 'static {
     type Task: AhnlichProtocol + Send + Sync + 'static;
     type PersistenceTask: AhnlichPersistenceUtils;
 
@@ -44,33 +44,15 @@ pub trait AhnlichServerUtils: Sized {
         stream: TcpStream,
         server_addr: SocketAddr,
         connected_client: ConnectedClient,
-    ) -> IoResult<Self::Task>;
+    ) -> Self::Task;
 
     fn local_addr(&self) -> IoResult<SocketAddr> {
         self.listener().local_addr()
     }
 
-    fn shutdown_token(&self) -> &Shutdown;
-    fn shutdown_token_owned(self) -> Shutdown;
+    fn cancellation_token(&self) -> CancellationToken;
 
-    fn cancellation_token(&self) -> &CancellationToken;
-
-    /// stops all tasks and performs cleanup
-    async fn shutdown(self) {
-        let service_name = self.config().service_name;
-        // TODO: Add cleanup for instance persistence
-        // just cancelling the token alone does not give enough time for each task to shutdown,
-        // there must be other measures in place to ensure proper cleanup
-        if self
-            .shutdown_token_owned()
-            .shutdown_with_limit(Duration::from_secs(10))
-            .await
-            .is_err()
-        {
-            log::error!("{}: shutdown took longer than timeout", service_name);
-        };
-        tracer::shutdown_tracing();
-    }
+    fn task_manager(&self) -> Arc<TaskManager>;
 
     /// Runs through several processes to start up the server
     /// - Sets global allocator cap
@@ -87,57 +69,58 @@ pub trait AhnlichServerUtils: Sized {
 
         log::debug!("Set max size for global allocator to: {global_allocator_cap}");
         let server_addr = self.local_addr()?;
+        let task_manager = self.task_manager();
+        let inner_task_manager = self.task_manager();
+        let waiting_task_manager = self.task_manager();
         if let Some(persist_location) = self.config().persist_location {
-            let persistence_task = Persistence::task(
+            let persistence_task = Arc::new(Persistence::task(
                 self.write_flag(),
                 self.config().persistence_interval,
                 persist_location,
                 self.store_handler().get_snapshot(),
-            );
-            self.shutdown_token()
-                .spawn_task_fn(|guard| async move { persistence_task.monitor(guard).await });
+            ));
+            task_manager
+                .spawn_task_loop(
+                    async move { persistence_task.run().await },
+                    "persistence".to_string(),
+                )
+                .await;
         };
-        loop {
-            let shutdown_guard = self.shutdown_token().guard();
-            select! {
-                // We use biased selection as it would order our futures according to physical
-                // arrangements below
-                // We want shutdown signals to always be checked for first, hence the arrangements
-                biased;
-
-                // shutdown handler from Ctrl+C signals
-                _ = shutdown_guard.cancelled() => {
-                    // need to drop the shutdown guard used here else self.shutdown times out
-                    log::info!("Kill signal received for shutdown");
-                    drop(shutdown_guard);
-                    self.shutdown().await;
-                    break Ok(());
-                }
-                // shutdown handler from external cancellation tokens
-                _ = self.cancellation_token().cancelled() => {
-                    log::info!("External thread triggered cancellation token");
-                    drop(shutdown_guard);
-                    self.shutdown().await;
-                    break Ok(());
-                }
-                Ok((stream, connect_addr)) = self.listener().accept() => {
-                    //  - Spawn a tokio task to handle the command while holding on to a reference to self
-                    //  - Convert the incoming bincode in a chunked manner to a Vec<AIQuery>
-                    //  - Use store_handler to process the queries
-                    //  - Block new incoming connections on shutdown by no longer accepting and then
-                    //  cancelling existing ServerTask or forcing them to run to completion
-
-                    if let Some(connected_client) = self.client_handler().connect(stream.peer_addr()?) {
-                        log::info!("Connecting to {}", connect_addr);
-                        let mut task = self.create_task(stream, server_addr, connected_client)?;
-                        shutdown_guard.spawn_task_fn(|guard| async move {
-                            if let Err(e) = task.process(guard).instrument(tracing::info_span!("server_task").or_current()).await {
-                                log::error!("Error handling connection: {}", e)
-                            };
-                        });
+        task_manager
+            .spawn_task_loop(
+                async move {
+                    if let Ok((stream, connect_addr)) = self.listener().accept().await {
+                        if let Some(connected_client) = self
+                            .client_handler()
+                            .connect(stream.peer_addr().expect("Could not get peer addr"))
+                        {
+                            log::info!("Connecting to {}", connect_addr);
+                            let mut task = self.create_task(stream, server_addr, connected_client);
+                            inner_task_manager
+                                .spawn_task_loop(
+                                    async move {
+                                        task.process()
+                                            .instrument(
+                                                tracing::info_span!("server_task").or_current(),
+                                            )
+                                            .await
+                                    },
+                                    format!("{}-listener", connect_addr),
+                                )
+                                .await;
+                        } else {
+                            return TaskLoopControl::Break;
+                        }
                     }
-                }
-            }
-        }
+                    TaskLoopControl::Continue
+                },
+                "listener".to_string(),
+            )
+            .await;
+        log::debug!("Spawned all tasks");
+        waiting_task_manager.wait().await;
+        tracer::shutdown_tracing();
+        log::info!("Shutdown complete");
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR swaps out `tokio_graceful::Shutdown` for `task_manager::TaskManager`. The signatures are almost replicas but with advantages to `TaskManager` as follows:
- Completely clonable. This will come in handy as we can spin up the AI inference thread using the task_manager before calling `ai_server.start()`
- Using `tokio_util::task::TaskTracker`, we are able to track every task(spawned thread) and wait for every thread to complete before shutdown. This can also let us know the exact amount of running threads by calling `.len()`