### PR TITLE
Creating ModelManager to init and communicate with multiple ModelThread

### DIFF
--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -6,7 +6,7 @@ use crate::engine::ai::models::{Model, ModelInfo};
 use std::io::Write;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, VariantArray)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Hash, Ord, ValueEnum, VariantArray)]
 pub enum SupportedModels {
     Llama3,
     Dalle3,

--- a/ahnlich/ai/src/engine/store.rs
+++ b/ahnlich/ai/src/engine/store.rs
@@ -117,8 +117,8 @@ impl AIStoreHandler {
 
                 AIStoreInfo {
                     name: store_name.clone(),
-                    query_model: store.query_model.clone(),
-                    index_model: store.index_model.clone(),
+                    query_model: store.query_model,
+                    index_model: store.index_model,
                     embedding_size: model.embedding_size().into(),
                 }
             })

--- a/ahnlich/ai/src/error.rs
+++ b/ahnlich/ai/src/error.rs
@@ -3,8 +3,9 @@ use ahnlich_types::{
     keyval::StoreName,
 };
 use thiserror::Error;
+use tokio::sync::oneshot::error::RecvError;
 
-#[derive(Error, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Error, Debug, Eq, PartialEq)]
 pub enum AIProxyError {
     #[error("Store {0} not found")]
     StoreNotFound(StoreName),
@@ -53,6 +54,13 @@ pub enum AIProxyError {
 
     #[error("index_model or query_model not selected during aiproxy startup")]
     AIModelNotInitialized,
+
+    // TODO: Add SendError from mpsc::Sender into this variant
+    #[error("Error sending request to model thread")]
+    AIModelThreadSendError,
+
+    #[error("Error receiving response from model thread")]
+    AIModelRecvError(#[from] RecvError),
 
     #[error("Dimensions Mismatch between index [{index_model_dim}], and Query [{query_model_dim}] Models")]
     DimensionsMismatchError {

--- a/ahnlich/ai/src/lib.rs
+++ b/ahnlich/ai/src/lib.rs
@@ -3,6 +3,7 @@ use ahnlich_types::metadata::MetadataKey;
 pub mod cli;
 pub mod engine;
 pub mod error;
+mod manager;
 pub mod server;
 use once_cell::sync::Lazy;
 #[cfg(test)]

--- a/ahnlich/ai/src/manager/mod.rs
+++ b/ahnlich/ai/src/manager/mod.rs
@@ -57,8 +57,9 @@ impl Task for ModelThread {
             if let Err(e) = response.send(self.input_to_response(inputs)) {
                 log::error!("{} could not send response to channel {e:?}", self.name());
             }
+            return TaskState::Continue;
         }
-        TaskState::Continue
+        TaskState::Break
     }
 }
 

--- a/ahnlich/ai/src/manager/mod.rs
+++ b/ahnlich/ai/src/manager/mod.rs
@@ -1,0 +1,128 @@
+/// The ModelManager is a wrapper around all the AI models running on various green threads. It
+/// lets AIProxyTasks communicate with any model to receive immediate responses via a oneshot
+/// channel
+use crate::cli::server::SupportedModels;
+use crate::error::AIProxyError;
+use ahnlich_types::ai::AIModel;
+use ndarray::Array1;
+use std::collections::HashMap;
+use task_manager::TaskManager;
+use task_manager::TaskManagerGuard;
+use tokio::sync::{mpsc, oneshot};
+
+type ModelThreadResponse = Result<Vec<Array1<f32>>, AIProxyError>;
+
+struct ModelThreadRequest {
+    // TODO: change this to a Vec of preprocessed input enum
+    inputs: (),
+    response: oneshot::Sender<ModelThreadResponse>,
+}
+
+#[derive(Debug)]
+struct ModelThread {
+    model: SupportedModels,
+    request_receiver: mpsc::Receiver<ModelThreadRequest>,
+}
+
+impl ModelThread {
+    fn new(model: SupportedModels, request_receiver: mpsc::Receiver<ModelThreadRequest>) -> Self {
+        Self {
+            request_receiver,
+            model,
+        }
+    }
+
+    fn name(&self) -> String {
+        format!("{:?}-model-thread", self.model)
+    }
+
+    fn input_to_response(&self, _inputs: ()) -> ModelThreadResponse {
+        Ok(vec![])
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn run(&mut self, guard: TaskManagerGuard) {
+        loop {
+            tokio::select! {
+                biased;
+
+                _ = guard.is_cancelled() => {
+                    // TODO: Run cleanup for model thread exit
+                    // This should be safe to do as the guard would wait
+                    break;
+                }
+                Some(model_request) = self.request_receiver.recv() => {
+                    // TODO actually service model request in here and return
+                    let ModelThreadRequest {
+                        inputs,
+                        response,
+                    } = model_request;
+                    if let Err(e) = response.send(self.input_to_response(inputs)) {
+                        log::error!("{} could not send response to channel {e:?}", self.name());
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ModelManager {
+    _models: HashMap<SupportedModels, mpsc::Sender<ModelThreadRequest>>,
+}
+
+impl ModelManager {
+    pub async fn new(
+        supported_models: &[SupportedModels],
+        task_manager: &TaskManager,
+    ) -> Result<Self, AIProxyError> {
+        // TODO: Actually load the model at this point, with supported models and throw up errors,
+        // also start up the various models with the task manager passed in
+        //
+        let mut models = HashMap::with_capacity(supported_models.len());
+        for model in supported_models {
+            // QUESTION? Should we hard code the buffer size or add it to config?
+            let (request_sender, request_receiver) = mpsc::channel(100);
+            // There may be other things needed to load a model thread
+            let mut model_thread = ModelThread::new(*model, request_receiver);
+            let model_thread_name = model_thread.name();
+            task_manager
+                .spawn_task_loop(
+                    |shutdown_guard| async move { model_thread.run(shutdown_guard).await },
+                    model_thread_name,
+                )
+                .await;
+            models.insert(model, request_sender);
+        }
+        Ok(Self {
+            _models: HashMap::new(),
+        })
+    }
+
+    #[tracing::instrument(skip(self, inputs))]
+    pub async fn handle_request(
+        &self,
+        model: &AIModel,
+        inputs: (),
+    ) -> Result<Vec<Array1<f32>>, AIProxyError> {
+        let supported = model.into();
+        if let Some(sender) = self._models.get(&supported) {
+            let (response_tx, response_rx) = oneshot::channel();
+            let request = ModelThreadRequest {
+                inputs,
+                response: response_tx,
+            };
+            // TODO: Add potential timeouts for send and recieve in case threads are unresponsive
+            if sender.send(request).await.is_ok() {
+                response_rx
+                    .await
+                    .map_err(|e| e.into())
+                    .and_then(|inner| inner)
+            } else {
+                return Err(AIProxyError::AIModelThreadSendError);
+            }
+        } else {
+            return Err(AIProxyError::AIModelNotInitialized);
+        }
+    }
+}

--- a/ahnlich/task-manager/Cargo.toml
+++ b/ahnlich/task-manager/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 tokio-util.workspace = true
 tokio.workspace = true
 log.workspace = true
+async-trait.workspace = true

--- a/ahnlich/types/src/ai/mod.rs
+++ b/ahnlich/types/src/ai/mod.rs
@@ -9,7 +9,7 @@ use std::fmt;
 
 use crate::keyval::StoreInput;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AIModel {
     // Image model
     DALLE3,

--- a/ahnlich/utils/src/protocol.rs
+++ b/ahnlich/utils/src/protocol.rs
@@ -137,7 +137,7 @@ where
                         }
                     }
                     Err(error) => {
-                        let error = self.prefix_log(&format!(
+                        let error = self.prefix_log(format!(
                             "Could not deserialize client message as server query {error}"
                         ));
                         log::error!("{error}");

--- a/ahnlich/utils/src/protocol.rs
+++ b/ahnlich/utils/src/protocol.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 use std::io::Error;
 use std::io::ErrorKind;
 use std::sync::Arc;
-use task_manager::TaskManagerGuard;
+use task_manager::TaskState;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
@@ -36,135 +36,125 @@ where
     }
 
     /// processes messages from a stream
-    async fn process(&self, shutdown_guard: TaskManagerGuard) {
+    async fn process(&self) -> TaskState {
         let mut magic_bytes_buf = [0u8; MAGIC_BYTES.len()];
         let mut version_buf = [0u8; VERSION_LENGTH];
         let mut length_buf = [0u8; LENGTH_HEADER_SIZE];
         let reader = self.reader();
         let mut reader = reader.lock().await;
-        loop {
-            tokio::select! {
-                biased;
-
-                _ = shutdown_guard.is_cancelled() => {
-                    break;
+        match reader.read_exact(&mut magic_bytes_buf).await {
+            Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                let error = self.prefix_log("Hung up on buffered stream");
+                log::error!("{error}");
+                return TaskState::Break;
+            }
+            Err(e) => {
+                let error = self.prefix_log(format!("Error reading from task buffered stream {e}"));
+                log::error!("{error}");
+                return TaskState::Break;
+            }
+            Ok(_) => {
+                if magic_bytes_buf != MAGIC_BYTES {
+                    let error = "Invalid request stream".to_string();
+                    log::error!("{error}");
+                    return TaskState::Break;
                 }
-                res = reader.read_exact(&mut magic_bytes_buf) => {
-                    match res {
-                        Err(ref e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                            let error = self.prefix_log("Hung up on buffered stream");
-                            log::error!("{error}");
-                            break;
-                        }
-                        Err(e) => {
-                            let error = self.prefix_log(format!("Error reading from task buffered stream {e}"));
-                            log::error!("{error}");
-                            break
-                        }
-                        Ok(_) => {
-                            if magic_bytes_buf != MAGIC_BYTES {
-                                let error = "Invalid request stream".to_string();
-                                log::error!("{error}");
-                                break;
-                            }
-                            if let Err(e) = reader.read_exact(&mut version_buf).await {
-                                log::error!("{}", e.to_string());
-                                break;
-                            }
-                            let version = match Version::deserialize_magic_bytes(&version_buf) {
-                                Ok(version) => version,
+                if let Err(e) = reader.read_exact(&mut version_buf).await {
+                    log::error!("{}", e.to_string());
+                    return TaskState::Break;
+                }
+                let version = match Version::deserialize_magic_bytes(&version_buf) {
+                    Ok(version) => version,
+                    Err(error) => {
+                        let error = format!("Unable to parse version chunk {error}");
+                        log::error!("{error}");
+                        return TaskState::Break;
+                    }
+                };
+                if !VERSION.is_compatible(&version) {
+                    let error = format!(
+                        "Incompatible versions, Server: {:?}, Client {version:?}",
+                        *VERSION
+                    );
+                    log::error!("{error}");
+                    return TaskState::Break;
+                }
+                // cap the message size to be of length 1MiB
+                if let Err(e) = reader.read_exact(&mut length_buf).await {
+                    let error = format!("Could not read length buffer {e}");
+                    log::error!("{error}");
+                    return TaskState::Break;
+                };
+                let data_length = u64::from_le_bytes(length_buf);
+                if data_length > self.maximum_message_size() {
+                    let error = self.prefix_log(format!(
+                        "Message cannot exceed {} bytes, configure `message_size` for higher",
+                        self.maximum_message_size()
+                    ));
+                    log::error!("{error}");
+                    return TaskState::Break;
+                }
+                let mut data = Vec::new();
+                if data.try_reserve(data_length as usize).is_err() {
+                    let error = self
+                        .prefix_log(format!("failed to reserve buffer of length {data_length}"));
+                    log::error!("{error}");
+                    return TaskState::Break;
+                };
+                data.resize(data_length as usize, 0u8);
+                if let Err(e) = reader.read_exact(&mut data).await {
+                    let error = format!("Could not read data buffer {e}");
+                    log::error!("{error}");
+                    return TaskState::Break;
+                };
+                match Self::ServerQuery::deserialize(&data) {
+                    Ok(queries) => {
+                        log::debug!("Got Queries {:?}", queries);
+                        let span = tracing::info_span!("query-processor");
+                        if let Some(trace_parent) = queries.get_traceparent() {
+                            let parent_context = match tracer::trace_parent_to_span(trace_parent)
+                                .map_err(|err| Error::new(ErrorKind::Other, err))
+                            {
+                                Ok(parent_context) => parent_context,
                                 Err(error) => {
-                                    let error = format!("Unable to parse version chunk {error}");
                                     log::error!("{error}");
-                                    break;
+                                    return TaskState::Break;
                                 }
                             };
-                            if !VERSION.is_compatible(&version) {
-                                let error = format!(
-                                    "Incompatible versions, Server: {:?}, Client {version:?}",
-                                    *VERSION
-                                );
-                                log::error!("{error}");
-                                break;
-                            }
-                            // cap the message size to be of length 1MiB
-                            if let Err(e) = reader.read_exact(&mut length_buf).await {
-                                let error = format!("Could not read length buffer {e}");
-                                log::error!("{error}");
-                                break;
-                            };
-                            let data_length = u64::from_le_bytes(length_buf);
-                            if data_length > self.maximum_message_size() {
-                                let error = self.prefix_log(format!(
-                                        "Message cannot exceed {} bytes, configure `message_size` for higher",
-                                        self.maximum_message_size()
-                                ));
-                                log::error!("{error}");
-                                break;
-                            }
-                            let mut data = Vec::new();
-                            if data.try_reserve(data_length as usize).is_err() {
-                                let error = self
-                                    .prefix_log(format!("failed to reserve buffer of length {data_length}"));
-                                log::error!("{error}");
-                                break;
-                            };
-                            data.resize(data_length as usize, 0u8);
-                            if let Err(e) = reader.read_exact(&mut data).await {
-                                let error = format!("Could not read data buffer {e}");
-                                log::error!("{error}");
-                                break;
-                            };
-                            match Self::ServerQuery::deserialize(&data) {
-                                Ok(queries) => {
-                                    log::debug!("Got Queries {:?}", queries);
-                                    let span = tracing::info_span!("query-processor");
-                                    if let Some(trace_parent) = queries.get_traceparent() {
-                                        let parent_context = match tracer::trace_parent_to_span(trace_parent)
-                                            .map_err(|err| Error::new(ErrorKind::Other, err))
-                                            {
-                                                Ok(parent_context) => parent_context,
-                                                Err(error) => {
-                                                    log::error!("{error}");
-                                                    break;
-                                                }
-                                            };
-                                        span.set_parent(parent_context);
-                                    }
-                                    let results = self.handle(queries.into_inner()).instrument(span).await;
-                                    if let Ok(binary_results) = results.serialize() {
-                                        if let Err(error) = reader.get_mut().write_all(&binary_results).await {
-                                            log::error!("{error}");
-                                            break;
-                                        };
-                                        log::debug!(
-                                            "Sent Response of length {}, {:?}",
-                                            binary_results.len(),
-                                            binary_results
-                                        );
-                                    }
-                                }
-                                Err(error) => {
-                                    let error = self.prefix_log(&format!(
-                                            "Could not deserialize client message as server query {error}"
-                                    ));
-                                    log::error!("{error}");
-                                    let deserialize_error = Self::ServerResponse::from_error(
-                                        "Could not deserialize query, error is {e}".to_string(),
-                                    )
-                                        .serialize()
-                                        .expect("Could not serialize deserialize error");
-                                    if let Err(error) = reader.get_mut().write_all(&deserialize_error).await {
-                                        log::error!("{error}");
-                                        break;
-                                    };
-                                }
-                            }
+                            span.set_parent(parent_context);
                         }
+                        let results = self.handle(queries.into_inner()).instrument(span).await;
+                        if let Ok(binary_results) = results.serialize() {
+                            if let Err(error) = reader.get_mut().write_all(&binary_results).await {
+                                log::error!("{error}");
+                                return TaskState::Break;
+                            };
+                            log::debug!(
+                                "Sent Response of length {}, {:?}",
+                                binary_results.len(),
+                                binary_results
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        let error = self.prefix_log(&format!(
+                            "Could not deserialize client message as server query {error}"
+                        ));
+                        log::error!("{error}");
+                        let deserialize_error = Self::ServerResponse::from_error(
+                            "Could not deserialize query, error is {e}".to_string(),
+                        )
+                        .serialize()
+                        .expect("Could not serialize deserialize error");
+                        if let Err(error) = reader.get_mut().write_all(&deserialize_error).await {
+                            log::error!("{error}");
+                            return TaskState::Break;
+                        };
                     }
                 }
             }
         }
+        TaskState::Continue
     }
 
     async fn handle(


### PR DESCRIPTION
This PR sets up the entry points for running models on individual threads already loaded up in memory at the start of the program

- `ModelThread` : A single model running on a thread. It receives `ModelThreadRequest`(s) via an mpsc channel, with the only way of response being a oneshot channel Sender passed within the request itself
- `ModelManager`: Spins up multiple `ModelThread`(s) via the passed in `TaskManager`. Provides helper method `handle_request` to communicate with each model like a regular async call
- `ModelThreadRequest`:  internal structure for communication between the `ModelManager` and `ModelThread`(s)
- `ModelThreadResponse`: the response of the model thread which could potentially error i.e it is unable to turn inputs into `Vec<Array1<f32>>`

As a side, we could/might be able to move preprocessing into the `ModelManager` but that's if you believe it's worth it @Iamdavidonuh  @HAKSOAT 