### PR TITLE
Swap our ModelManager Hashmap for Moka Cache

### DIFF
--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -37,6 +37,7 @@ strum = { version = "0.26", features = ["derive"] }
 log.workspace = true
 fallible_collections.workspace = true
 rayon.workspace = true
+moka = { version = "0.12.8", features = ["future"] }
 
 [dev-dependencies]
 db = { path = "../db", version = "*" }

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -94,6 +94,12 @@ pub struct AIProxyConfig {
     /// List of ai models to support in your aiproxy stores
     #[arg(long, required(true), value_delimiter = ',')]
     pub(crate) supported_models: Vec<SupportedModels>,
+
+    /// AI Model Idle Time in seconds
+    /// Time in seconds for an unused/idle supported model to be frozen
+    /// Defaults to 5 mins
+    #[arg(long, default_value_t = 60 * 5)]
+    pub(crate) ai_model_idle_time: u64,
 }
 
 impl Default for AIProxyConfig {
@@ -118,6 +124,8 @@ impl Default for AIProxyConfig {
             log_level: String::from("info"),
             maximum_clients: 1000,
             supported_models: vec![SupportedModels::Llama3, SupportedModels::Dalle3],
+
+            ai_model_idle_time: 60 * 5,
         }
     }
 }

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -96,8 +96,9 @@ pub struct AIProxyConfig {
     pub(crate) supported_models: Vec<SupportedModels>,
 
     /// AI Model Idle Time in seconds
-    /// Time in seconds for an unused/idle supported model to be frozen
     /// Defaults to 5 mins
+    /// Time in seconds for an unused/idle supported model to be dropped
+    /// Futher calls after a drop reinitializes the model from scratch
     #[arg(long, default_value_t = 60 * 5)]
     pub(crate) ai_model_idle_time: u64,
 }

--- a/ahnlich/ai/src/error.rs
+++ b/ahnlich/ai/src/error.rs
@@ -70,6 +70,9 @@ pub enum AIProxyError {
     },
     #[error("allocation error {0:?}")]
     Allocation(TryReserveError),
+
+    #[error("Error initializing a model thread {0}")]
+    ModelInitializationError(String),
 }
 
 impl From<TryReserveError> for AIProxyError {

--- a/ahnlich/ai/src/manager/mod.rs
+++ b/ahnlich/ai/src/manager/mod.rs
@@ -256,6 +256,22 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn test_model_manager_setup_works() {
+        let supported_models = vec![SupportedModels::Llama3, SupportedModels::Dalle3];
+
+        let task_manager = Arc::new(TaskManager::new());
+        let time_to_idle: u64 = 5;
+        let model_manager = ModelManager::new(&supported_models, task_manager, time_to_idle)
+            .await
+            .unwrap();
+
+        for model in supported_models {
+            let recreated_model = model_manager.models.get(&model).await;
+            assert!(recreated_model.is_some());
+        }
+    }
+
+    #[tokio::test]
     async fn test_model_manager_refreshes_evicted_model() {
         let supported_models = vec![SupportedModels::Llama3, SupportedModels::Dalle3];
         let sample_ai_model = AIModel::Llama3;

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -119,8 +119,9 @@ impl AIProxyServer {
             }
         };
         let client_handler = Arc::new(ClientHandler::new(config.maximum_clients));
-        let task_manager = TaskManager::new();
-        let model_manager = ModelManager::new(&config.supported_models, &task_manager).await?;
+        let task_manager = Arc::new(TaskManager::new());
+        let model_manager =
+            ModelManager::new(&config.supported_models, task_manager.clone()).await?;
 
         Ok(Self {
             listener: Arc::new(listener),
@@ -128,7 +129,7 @@ impl AIProxyServer {
             store_handler: Arc::new(store_handler),
             config,
             db_client: Arc::new(db_client),
-            task_manager: Arc::new(task_manager),
+            task_manager,
             model_manager: Arc::new(model_manager),
         })
     }

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -120,8 +120,12 @@ impl AIProxyServer {
         };
         let client_handler = Arc::new(ClientHandler::new(config.maximum_clients));
         let task_manager = Arc::new(TaskManager::new());
-        let model_manager =
-            ModelManager::new(&config.supported_models, task_manager.clone()).await?;
+        let model_manager = ModelManager::new(
+            &config.supported_models,
+            task_manager.clone(),
+            config.ai_model_idle_time,
+        )
+        .await?;
 
         Ok(Self {
             listener: Arc::new(listener),


### PR DESCRIPTION
This PR allows dropping model threads after some defined idle time in aiproxyconfig.
- Swapped out Hashmap for moka cache, to set TTI
- Added tests to show a model thread was recreated after idle time had passed