### PR TITLE
Fixing lack of image within ai response

### DIFF
--- a/ahnlich/typegen/src/tracers/server_response/ai.rs
+++ b/ahnlich/typegen/src/tracers/server_response/ai.rs
@@ -55,6 +55,7 @@ pub fn trace_ai_server_response_enum() -> Registry {
     });
 
     let store_input = StoreInput::RawString("testing".into());
+    let test_search_input_bin = StoreInput::Image(vec![2, 1, 1, 4, 5]);
 
     //StoreValue = StdHashMap<MetadataKey, MetadataValue>
     let mut store_value = StdHashMap::new();
@@ -67,7 +68,10 @@ pub fn trace_ai_server_response_enum() -> Registry {
         MetadataValue::Image(vec![6, 4, 2]),
     );
 
-    let get_variant = AIServerResponse::Get(vec![(store_input.clone(), store_value.clone())]);
+    let get_variant = AIServerResponse::Get(vec![
+        (store_input.clone(), store_value.clone()),
+        (test_search_input_bin, store_value.clone()),
+    ]);
 
     // getsminN
 

--- a/sdk/ahnlich-client-py/ahnlich_client_py/internals/ai_response.py
+++ b/sdk/ahnlich-client-py/ahnlich_client_py/internals/ai_response.py
@@ -361,8 +361,15 @@ class StoreInput__RawString(StoreInput):
     value: str
 
 
+@dataclass(frozen=True)
+class StoreInput__Image(StoreInput):
+    INDEX = 1  # type: int
+    value: typing.Sequence[st.uint8]
+
+
 StoreInput.VARIANTS = [
     StoreInput__RawString,
+    StoreInput__Image,
 ]
 
 

--- a/sdk/ahnlich-client-py/ahnlich_client_py/internals/pool_wrapper.py
+++ b/sdk/ahnlich-client-py/ahnlich_client_py/internals/pool_wrapper.py
@@ -34,7 +34,6 @@ class AhnlichTcpSocketConnectionManager(TcpSocketConnectionManager):
         conn: socket.socket,
         timeout: float | None = None,
     ) -> bool:
-
         try:
             with socket_nonblocking(conn):
                 if conn.recv(1, socket.MSG_PEEK) == b"":

--- a/type_specs/response/ai_response.json
+++ b/type_specs/response/ai_response.json
@@ -233,6 +233,13 @@
         "RawString": {
           "NEWTYPE": "STR"
         }
+      },
+      "1": {
+        "Image": {
+          "NEWTYPE": {
+            "SEQ": "U8"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
This fixes the issue noticed by @HAKSOAT where ai response does not have the image variant within `StoreInput`. `typegen` is extremely weird and doesn't feel like something we will continue usage of within the long run. An issue can be opened to start considering other things like `capnp`