### PR TITLE
Adding various GPU execution providers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
                 echo "BIN_SUFFIX=${value}" >> $GITHUB_OUTPUT
                 echo "BIN_NAME=ahnlich-${value}" >> $GITHUB_OUTPUT
 
-    build_linux_binaries_and_publish:
+    build_linux_x86-64_binaries_and_publish:
         needs: prebuild_preparation
-        name: Build Linux Binaries
+        name: Build Linux x86_64 Binaries
         runs-on: ubuntu-latest
         steps:
             - name: "Checkout"
@@ -46,9 +46,34 @@ jobs:
             - name: Build Linux Release for ${{ needs.prebuild_preparation.outputs.bin_name }}
               working-directory: ./ahnlich
               run: |
-                cargo build --release --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
-                tar -cvzf linux-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/release ${{ needs.prebuild_preparation.outputs.bin_name }}
-                gh release upload ${{github.event.release.tag_name}} linux-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
+                cargo build --release --target x86_64-unknown-linux-gnu --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                tar -cvzf x86_64-linux-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/x86_64-unknown-linux-gnu/release ${{ needs.prebuild_preparation.outputs.bin_name }}
+                gh release upload ${{github.event.release.tag_name}} x86_64-linux-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
+
+              env:
+                GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+              shell: bash
+
+    build_linux_aarch64_binaries_and_publish:
+        needs: prebuild_preparation
+        name: Build Linux Aarch64 Binaries
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Checkout"
+              uses: actions/checkout@v4
+
+            - name: Get Cargo toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                toolchain: 1.81.0
+
+            - name: Build Linux Release for ${{ needs.prebuild_preparation.outputs.bin_name }}
+              working-directory: ./ahnlich
+              run: |
+                rustup target add aarch64-unknown-linux-gnu
+                cargo build --release --target aarch64-unknown-linux-gnu --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                tar -cvzf aarch64-linux-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/aarch64-unknown-linux-gnu/release ${{ needs.prebuild_preparation.outputs.bin_name }}
+                gh release upload ${{github.event.release.tag_name}} aarch64-linux-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
 
               env:
                 GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -73,8 +98,8 @@ jobs:
                 else
                   cargo build --release --target aarch64-apple-darwin --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
                 fi
-                tar -cvzf aarch64-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/aarch64-apple-darwin/release ${{ needs.prebuild_preparation.outputs.bin_name }}
-                gh release upload ${{github.event.release.tag_name}} aarch64-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz                
+                tar -cvzf aarch64-apple-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/aarch64-apple-darwin/release ${{ needs.prebuild_preparation.outputs.bin_name }}
+                gh release upload ${{github.event.release.tag_name}} aarch64-apple-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
 
               env:
                 GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -104,7 +129,7 @@ jobs:
                 fi
                 tar -cvzf x86_64-apple-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/x86_64-apple-darwin/release ${{ needs.prebuild_preparation.outputs.bin_name }}
                 
-                gh release upload ${{github.event.release.tag_name}} x86_64-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
+                gh release upload ${{github.event.release.tag_name}} x86_64-apple-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
 
               env:
                 GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,9 +54,9 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
               shell: bash
 
-    build_macos_darwin_binaries_and_publish:
+    build_macos_aarch64_binaries_and_publish:
         needs: prebuild_preparation
-        name: Build MacOs Darwin Binaries
+        name: Build MacOs Aarch64 Binaries
         runs-on: macos-latest
         outputs:
           bin_name: ${{ needs.prebuild_preparation.outputs.bin_name }}
@@ -68,7 +68,11 @@ jobs:
             - name: Build Aarch64 Darwin Release for ${{ needs.prebuild_preparation.outputs.bin_name }}
               working-directory: ./ahnlich
               run: |
-                cargo build --release --target aarch64-apple-darwin --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                if [ $BIN_NAME == "ahnlich-ai" ]; then
+                  cargo build --features coreml --release --target aarch64-apple-darwin --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                else
+                  cargo build --release --target aarch64-apple-darwin --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                fi
                 tar -cvzf aarch64-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/aarch64-apple-darwin/release ${{ needs.prebuild_preparation.outputs.bin_name }}
                 gh release upload ${{github.event.release.tag_name}} aarch64-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz                
 
@@ -90,13 +94,17 @@ jobs:
               with:
                 toolchain: 1.81.0
 
-            - name: Build x86_64 Apple Darwin Release for ${{ needs.prebuild_preparation.outputs.bin_name }}
+            - name: Build x86_64 Darwin Release for ${{ needs.prebuild_preparation.outputs.bin_name }}
               working-directory: ./ahnlich
               run: |
-                cargo build --release --target x86_64-apple-darwin --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                if [ $BIN_NAME == "ahnlich-ai" ]; then
+                  cargo build --features coreml --release --target x86_64-apple-darwin --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                else
+                  cargo build --release --target x86_64-apple-darwin --bin ${{ needs.prebuild_preparation.outputs.bin_name }}
+                fi
                 tar -cvzf x86_64-apple-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz -C target/x86_64-apple-darwin/release ${{ needs.prebuild_preparation.outputs.bin_name }}
                 
-                gh release upload ${{github.event.release.tag_name}} x86_64-apple-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
+                gh release upload ${{github.event.release.tag_name}} x86_64-darwin-${{ needs.prebuild_preparation.outputs.bin_name }}.tar.gz
 
               env:
                 GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/ahnlich/.cargo/config.toml
+++ b/ahnlich/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-apple-darwin]
+rustflags = ["-Clink-arg=-fapple-link-rtlib"]
+ 
+[target.x86_64-apple-darwin]
+rustflags = ["-Clink-arg=-fapple-link-rtlib"]

--- a/ahnlich/Cargo.lock
+++ b/ahnlich/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "nonzero_ext",
  "once_cell",
  "ort",
+ "ort-sys",
  "pretty_assertions",
  "rayon",
  "serde",

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -42,7 +42,6 @@ hf-hub = { version = "0.3", default-features = false }
 dirs = "5.0.1"
 ort = { version = "=2.0.0-rc.5", features = [
   "ndarray",
-  "directml",
   "tensorrt",
   "cuda",
   "coreml",

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -42,9 +42,6 @@ hf-hub = { version = "0.3", default-features = false }
 dirs = "5.0.1"
 ort = { version = "=2.0.0-rc.5", features = [
   "ndarray",
-  "tensorrt",
-  "cuda",
-  "coreml",
 ] }
 ort-sys = "=2.0.0-rc.8"
 moka = { version = "0.12.8", features = ["future"] }
@@ -53,6 +50,17 @@ futures.workspace = true
 tiktoken-rs = "0.5.9"
 itertools.workspace = true
 tokenizers = { version = "0.20.1", features = ["hf-hub"] }
+
+[features]
+# ORT Execution providers
+default = ["tensorrt", "cuda"]
+tensorrt = ["ort/tensorrt"]
+cuda = ["ort/cuda"]
+# activate only on apple devices
+coreml = ["ort/coreml"]
+# activate only on windows devices
+directml = ["ort/directml"]
+
 [dev-dependencies]
 db = { path = "../db", version = "*" }
 pretty_assertions.workspace = true

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -40,7 +40,14 @@ fallible_collections.workspace = true
 rayon.workspace = true
 hf-hub = { version = "0.3", default-features = false }
 dirs = "5.0.1"
-ort = { version = "=2.0.0-rc.5", features = ["ndarray"] }
+ort = { version = "=2.0.0-rc.5", features = [
+  "ndarray",
+  "directml",
+  "tensorrt",
+  "cuda",
+  "coreml",
+] }
+ort-sys = "=2.0.0-rc.8"
 moka = { version = "0.12.8", features = ["future"] }
 tracing-opentelemetry.workspace = true
 futures.workspace = true

--- a/ahnlich/ai/src/engine/ai/providers/ort.rs
+++ b/ahnlich/ai/src/engine/ai/providers/ort.rs
@@ -5,10 +5,7 @@ use crate::error::AIProxyError;
 use fallible_collections::FallibleVec;
 use hf_hub::{api::sync::ApiBuilder, Cache};
 use itertools::Itertools;
-use ort::{
-    CUDAExecutionProvider, CoreMLExecutionProvider, DirectMLExecutionProvider,
-    TensorRTExecutionProvider,
-};
+use ort::{CUDAExecutionProvider, CoreMLExecutionProvider, TensorRTExecutionProvider};
 use ort::{Session, SessionOutputs, Value};
 use rayon::prelude::*;
 
@@ -359,8 +356,6 @@ impl ProviderTrait for ORTProvider {
                 // Prefer TensorRT over CUDA.
                 TensorRTExecutionProvider::default().build(),
                 CUDAExecutionProvider::default().build(),
-                // Use DirectML on Windows if NVIDIA EPs are not available
-                DirectMLExecutionProvider::default().build(),
                 // Or use ANE on Apple platforms
                 CoreMLExecutionProvider::default().build(),
             ])

--- a/ahnlich/ai/src/engine/ai/providers/ort.rs
+++ b/ahnlich/ai/src/engine/ai/providers/ort.rs
@@ -5,7 +5,10 @@ use crate::error::AIProxyError;
 use fallible_collections::FallibleVec;
 use hf_hub::{api::sync::ApiBuilder, Cache};
 use itertools::Itertools;
-use ort::{CUDAExecutionProvider, CoreMLExecutionProvider, TensorRTExecutionProvider};
+use ort::{
+    CUDAExecutionProvider, CoreMLExecutionProvider, DirectMLExecutionProvider,
+    TensorRTExecutionProvider,
+};
 use ort::{Session, SessionOutputs, Value};
 use rayon::prelude::*;
 
@@ -356,6 +359,8 @@ impl ProviderTrait for ORTProvider {
                 // Prefer TensorRT over CUDA.
                 TensorRTExecutionProvider::default().build(),
                 CUDAExecutionProvider::default().build(),
+                // Use DirectML on Windows if NVIDIA EPs are not available
+                DirectMLExecutionProvider::default().build(),
                 // Or use ANE on Apple platforms
                 CoreMLExecutionProvider::default().build(),
             ])


### PR DESCRIPTION
Following execution provider documentation at https://ort.pyke.io/perf/execution-providers, this PR adds support for various GPU execution providers
- CoreML (Used by Apple Machines >= M1)
- TensorRT
- CUDA
- DirectML (Used by Windows devices)

Execution providers are loaded by `ort::init` in the order in which they are provided, whenever an execution provider is unavailable (either on the entire platform or for the operation in particular), the next available execution provider is used and if none is available, default CPU is used.


This has only been tested using `CoreML` on my Mac machine 

## Without `--features coreml` in build command
<img width="1440" alt="Screenshot 2024-12-16 at 11 59 32" src="https://github.com/user-attachments/assets/a95d6158-9340-403b-b864-94549f57280d" />


## With `--features coreml` in build command
<img width="1440" alt="Screenshot 2024-12-16 at 11 26 39" src="https://github.com/user-attachments/assets/8fd434a7-b35a-4389-994b-44fbf182a714" />

This also pins `ort-sys` dependency to `=2.0.0-rc.8` else we run into this [issue](https://github.com/pykeio/ort/issues/320)