### PR TITLE
Groundwork for some new non-linear algorithms

### DIFF
--- a/ahnlich/ai/src/server/task.rs
+++ b/ahnlich/ai/src/server/task.rs
@@ -455,7 +455,7 @@ impl AhnlichProtocol for AIProxyTask {
                 }
                 AIQuery::GetKey { store, keys } => {
                     let metadata_values: HashSet<MetadataValue> =
-                        keys.into_iter().map(|value| value.into()).collect();
+                        keys.into_par_iter().map(|value| value.into()).collect();
                     let get_key_condition = PredicateCondition::Value(Predicate::In {
                         key: AHNLICH_AI_RESERVED_META_KEY.clone(),
                         value: metadata_values,

--- a/ahnlich/db/src/algorithm/heap.rs
+++ b/ahnlich/db/src/algorithm/heap.rs
@@ -1,181 +1,18 @@
 #![allow(dead_code)]
 use super::LinearAlgorithm;
-use super::SimilarityVector;
-use ahnlich_types::keyval::StoreKey;
-use std::cmp::Reverse;
-use std::collections::BinaryHeap;
-use std::num::NonZeroUsize;
 
-pub(crate) struct MinHeap<'a> {
-    max_capacity: NonZeroUsize,
-    heap: BinaryHeap<Reverse<SimilarityVector<'a>>>,
+pub enum HeapOrder {
+    Min,
+    Max,
 }
 
-impl<'a> MinHeap<'a> {
-    pub(crate) fn new(capacity: NonZeroUsize) -> Self {
-        Self {
-            heap: BinaryHeap::new(),
-            max_capacity: capacity,
-        }
-    }
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn len(&self) -> usize {
-        self.heap.len()
-    }
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn push(&mut self, item: SimilarityVector<'a>) {
-        self.heap.push(Reverse(item));
-    }
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn pop(&mut self) -> Option<SimilarityVector<'a>> {
-        self.heap.pop().map(|popped_item| popped_item.0)
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn output(&mut self) -> Vec<(StoreKey, f32)> {
-        let mut result: Vec<_> = Vec::with_capacity(self.max_capacity.get());
-
-        loop {
-            match self.pop() {
-                Some(value) if result.len() < self.max_capacity.get() => {
-                    let vector_sim = value.0;
-                    result.push((vector_sim.0.clone(), vector_sim.1));
-                }
-                _ => break,
-            }
-        }
-        result
-    }
-}
-
-pub(crate) struct MaxHeap<'a> {
-    max_capacity: NonZeroUsize,
-    heap: BinaryHeap<SimilarityVector<'a>>,
-}
-
-impl<'a> MaxHeap<'a> {
-    pub(crate) fn new(capacity: NonZeroUsize) -> Self {
-        Self {
-            heap: BinaryHeap::new(),
-            max_capacity: capacity,
-        }
-    }
-    #[tracing::instrument(skip_all)]
-    fn push(&mut self, item: SimilarityVector<'a>) {
-        self.heap.push(item);
-    }
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn pop(&mut self) -> Option<SimilarityVector<'a>> {
-        self.heap.pop()
-    }
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn len(&self) -> usize {
-        self.heap.len()
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn output(&mut self) -> Vec<(StoreKey, f32)> {
-        let mut result: Vec<_> = Vec::with_capacity(self.max_capacity.get());
-
-        loop {
-            match self.heap.pop() {
-                Some(value) if result.len() < self.max_capacity.get() => {
-                    let vector_sim = value.0;
-                    result.push((vector_sim.0.clone(), vector_sim.1));
-                }
-                _ => break,
-            }
-        }
-        result
-    }
-}
-
-pub(crate) enum AlgorithmHeapType<'a> {
-    Min(MinHeap<'a>),
-    Max(MaxHeap<'a>),
-}
-
-impl<'a> AlgorithmHeapType<'a> {
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn push(&mut self, item: SimilarityVector<'a>) {
-        match self {
-            Self::Max(h) => h.push(item),
-            Self::Min(h) => h.push(item),
-        }
-    }
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn pop(&mut self) -> Option<SimilarityVector<'a>> {
-        match self {
-            Self::Max(h) => h.pop(),
-            Self::Min(h) => h.pop(),
-        }
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn output(&mut self) -> Vec<(StoreKey, f32)> {
-        match self {
-            Self::Min(h) => h.output(),
-            Self::Max(h) => h.output(),
-        }
-    }
-}
-
-impl From<(&LinearAlgorithm, NonZeroUsize)> for AlgorithmHeapType<'_> {
-    fn from((value, capacity): (&LinearAlgorithm, NonZeroUsize)) -> Self {
+impl From<&LinearAlgorithm> for HeapOrder {
+    fn from(value: &LinearAlgorithm) -> Self {
         match value {
-            LinearAlgorithm::EuclideanDistance => AlgorithmHeapType::Min(MinHeap::new(capacity)),
+            LinearAlgorithm::EuclideanDistance => HeapOrder::Min,
             LinearAlgorithm::CosineSimilarity | LinearAlgorithm::DotProductSimilarity => {
-                AlgorithmHeapType::Max(MaxHeap::new(capacity))
+                HeapOrder::Max
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn test_min_heap_ordering_works() {
-        let mut heap = MinHeap::new(NonZeroUsize::new(3).unwrap());
-        let mut count = 0.0;
-        let first_vector = StoreKey(ndarray::Array1::<f32>::zeros(2).map(|x| x + 2.0));
-
-        // If we pop these scores now, they should come back in the reverse order.
-        while count < 5.0 {
-            let similarity: f32 = 1.0 + count;
-
-            let item: SimilarityVector = (&first_vector, similarity).into();
-
-            heap.push(item);
-
-            count += 1.0;
-        }
-
-        assert_eq!(heap.pop(), Some((&first_vector, 1.0).into()));
-        assert_eq!(heap.pop(), Some((&first_vector, 2.0).into()));
-        assert_eq!(heap.pop(), Some((&first_vector, 3.0).into()));
-    }
-
-    #[test]
-    fn test_max_heap_ordering_works() {
-        let mut heap = MaxHeap::new(NonZeroUsize::new(3).unwrap());
-        let mut count = 0.0;
-        let first_vector = StoreKey(ndarray::Array1::<f32>::zeros(2).map(|x| x + 2.0));
-
-        // If we pop these scores now, they should come back  the right order(max first).
-        while count < 5.0 {
-            let similarity: f32 = 1.0 + count;
-            let item: SimilarityVector = (&first_vector, similarity).into();
-
-            heap.push(item);
-
-            count += 1.0;
-        }
-
-        assert_eq!(heap.pop(), Some((&first_vector, 5.0).into()));
-        assert_eq!(heap.pop(), Some((&first_vector, 4.0).into()));
-        assert_eq!(heap.pop(), Some((&first_vector, 3.0).into()));
     }
 }

--- a/ahnlich/db/src/algorithm/heap.rs
+++ b/ahnlich/db/src/algorithm/heap.rs
@@ -140,7 +140,7 @@ mod tests {
     fn test_min_heap_ordering_works() {
         let mut heap = MinHeap::new(NonZeroUsize::new(3).unwrap());
         let mut count = 0.0;
-        let first_vector = StoreKey(vec![2.0, 2.0]);
+        let first_vector = StoreKey(ndarray::Array1::<f32>::zeros(2).map(|x| x + 2.0));
 
         // If we pop these scores now, they should come back in the reverse order.
         while count < 5.0 {
@@ -162,7 +162,7 @@ mod tests {
     fn test_max_heap_ordering_works() {
         let mut heap = MaxHeap::new(NonZeroUsize::new(3).unwrap());
         let mut count = 0.0;
-        let first_vector = StoreKey(vec![2.0, 2.0]);
+        let first_vector = StoreKey(ndarray::Array1::<f32>::zeros(2).map(|x| x + 2.0));
 
         // If we pop these scores now, they should come back  the right order(max first).
         while count < 5.0 {

--- a/ahnlich/db/src/algorithm/non_linear.rs
+++ b/ahnlich/db/src/algorithm/non_linear.rs
@@ -62,7 +62,7 @@ impl FindSimilarN for NonLinearAlgorithmWithIndex {
     fn find_similar_n<'a>(
         &'a self,
         search_vector: &StoreKey,
-        search_list: impl Iterator<Item = &'a StoreKey>,
+        search_list: impl ParallelIterator<Item = &'a StoreKey>,
         used_all: bool,
         n: NonZeroUsize,
     ) -> Vec<(StoreKey, f32)> {

--- a/ahnlich/db/src/algorithm/non_linear.rs
+++ b/ahnlich/db/src/algorithm/non_linear.rs
@@ -2,20 +2,31 @@ use super::super::errors::ServerError;
 use super::FindSimilarN;
 use ahnlich_similarity::kdtree::KDTree;
 use ahnlich_similarity::utils::VecF32Ordered;
+use ahnlich_similarity::NonLinearAlgorithmWithIndexImpl;
 use ahnlich_types::keyval::StoreKey;
 use ahnlich_types::similarity::NonLinearAlgorithm;
 use flurry::HashMap as ConcurrentHashMap;
+use rayon::iter::IntoParallelIterator;
+use rayon::iter::ParallelIterator;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::mem::size_of_val;
 use std::num::NonZeroUsize;
 
+// Maintain an enum even though we have a trait as we want to know size
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) enum NonLinearAlgorithmWithIndex {
     KDTree(KDTree),
 }
+
 impl NonLinearAlgorithmWithIndex {
+    fn get_inner(&self) -> &impl NonLinearAlgorithmWithIndexImpl {
+        match self {
+            Self::KDTree(kdtree) => kdtree,
+        }
+    }
+
     #[tracing::instrument]
     pub(crate) fn create(algorithm: NonLinearAlgorithm, dimension: NonZeroUsize) -> Self {
         match algorithm {
@@ -28,31 +39,21 @@ impl NonLinearAlgorithmWithIndex {
 
     #[tracing::instrument(skip_all)]
     fn insert(&self, new: &[Vec<f32>]) {
-        match self {
-            NonLinearAlgorithmWithIndex::KDTree(kdtree) => {
-                kdtree
-                    .insert_multi(new.to_vec())
-                    .expect("Impossible dimension happened during insert of kdtree");
-            }
-        }
+        self.get_inner()
+            .insert(new.to_vec())
+            .expect("Error inserting into index");
     }
 
     #[tracing::instrument(skip_all)]
-    fn delete(&self, new: &[Vec<f32>]) {
-        match self {
-            NonLinearAlgorithmWithIndex::KDTree(kdtree) => {
-                kdtree
-                    .delete_multi(new)
-                    .expect("Impossible dimension happened during delete of kdtree");
-            }
-        }
+    fn delete(&self, del: &[Vec<f32>]) {
+        self.get_inner()
+            .delete(del)
+            .expect("Error deleting from index");
     }
 
     #[tracing::instrument(skip_all)]
     fn size(&self) -> usize {
-        match &self {
-            Self::KDTree(kdtree) => kdtree.size(),
-        }
+        self.get_inner().size()
     }
 }
 
@@ -74,17 +75,12 @@ impl FindSimilarN for NonLinearAlgorithmWithIndex {
                     .collect(),
             )
         };
-        match self {
-            NonLinearAlgorithmWithIndex::KDTree(kdtree) => {
-                kdtree
-                    .n_nearest(&search_vector.0, n, accept_list)
-                    // we expect that algorithm shapes have already been confirmed before hand
-                    .expect("KDTree does not have the same size as reference_point")
-                    .into_iter()
-                    .map(|(arr, sim)| (StoreKey(arr), sim))
-                    .collect()
-            }
-        }
+        self.get_inner()
+            .n_nearest(&search_vector.0, n, accept_list)
+            .expect("Index does not have the same size as reference_point")
+            .into_par_iter()
+            .map(|(arr, sim)| (StoreKey(arr), sim))
+            .collect()
     }
 }
 

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -444,7 +444,7 @@ impl Store {
     #[tracing::instrument(skip(self, input), fields(input_length=input.len()))]
     fn filter_dimension(&self, input: Vec<StoreKey>) -> Result<Vec<StoreKey>, ServerError> {
         input
-            .into_iter()
+            .into_par_iter()
             .map(|key| {
                 let store_dimension = self.dimension.get();
                 let input_dimension = key.dimension();

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -218,7 +218,7 @@ impl StoreHandler {
             return Ok(vec![]);
         }
 
-        let filtered_iter = filtered.iter().map(|(key, _)| key);
+        let filtered_iter = filtered.par_iter().map(|(key, _)| key);
 
         let algorithm_by_type: AlgorithmByType = algorithm.into();
         let similar_result = match algorithm_by_type {

--- a/ahnlich/similarity/src/kdtree.rs
+++ b/ahnlich/similarity/src/kdtree.rs
@@ -220,7 +220,7 @@ impl<'de> Deserialize<'de> for KDTree {
 
 struct NearestRecuriveArgs<'a> {
     node: &'a Atomic<KDNode>,
-    reference_point: &'a Vec<f32>,
+    reference_point: &'a [f32],
     depth: usize,
     n: NonZeroUsize,
     guard: &'a Guard,
@@ -574,7 +574,7 @@ impl NonLinearAlgorithmWithIndexImpl<'_> for KDTree {
     #[tracing::instrument(skip_all)]
     fn n_nearest(
         &self,
-        reference_point: &Vec<f32>,
+        reference_point: &[f32],
         n: NonZeroUsize,
         accept_list: Option<HashSet<VecF32Ordered>>,
     ) -> Result<Vec<(Vec<f32>, f32)>, Error> {

--- a/ahnlich/similarity/src/lib.rs
+++ b/ahnlich/similarity/src/lib.rs
@@ -1,4 +1,30 @@
+use std::{collections::HashSet, num::NonZeroUsize};
+
+use serde::{Deserialize, Serialize};
+use utils::VecF32Ordered;
+
 pub mod error;
 pub mod hnsw;
 pub mod kdtree;
 pub mod utils;
+
+pub trait NonLinearAlgorithmWithIndexImpl<'a>: Serialize + Deserialize<'a> {
+    // insert a batch of new inputs
+    fn insert(&self, new: Vec<Vec<f32>>) -> Result<(), error::Error>;
+    // delete a batch of new inputs
+    fn delete(&self, new: &[Vec<f32>]) -> Result<usize, error::Error>;
+    // find the N-nearest points to the reference point, if accept_list is Some(_), only select
+    // points from within the accept_list
+    //
+    // NOTE: that accept_list is triggered by sending predicate
+    // conditions and can significantly slow down non-linear predicates as it might trigger an
+    // almost linear search to find points within the accept list
+    fn n_nearest(
+        &self,
+        reference_point: &Vec<f32>,
+        n: NonZeroUsize,
+        accept_list: Option<HashSet<VecF32Ordered>>,
+    ) -> Result<Vec<(Vec<f32>, f32)>, error::Error>;
+    // size of index structure
+    fn size(&self) -> usize;
+}

--- a/ahnlich/similarity/src/lib.rs
+++ b/ahnlich/similarity/src/lib.rs
@@ -21,7 +21,7 @@ pub trait NonLinearAlgorithmWithIndexImpl<'a>: Serialize + Deserialize<'a> {
     // almost linear search to find points within the accept list
     fn n_nearest(
         &self,
-        reference_point: &Vec<f32>,
+        reference_point: &[f32],
         n: NonZeroUsize,
         accept_list: Option<HashSet<VecF32Ordered>>,
     ) -> Result<Vec<(Vec<f32>, f32)>, error::Error>;


### PR DESCRIPTION
- Moved some shared characteristics of non-linear algorithms into a trait. Still fronted by an enum in the end but this then lets target implementation of behavior be more obvious for contribution
- Made linear algorithms to use `ParallelIterator` as opposed to regular `Iterator`. Given that `BinaryHeap<T: Ord>` is collectible from any iterator (including parallel iterators), all the looping we are doing below just comes to the surface within `FindSimilarN for LinearAlgorithm`. We also only `StoreKey::clone` after popping the N nearest from the heap as that could potentially mean a lot less clones than doing it before