### PR TITLE
added padding, cards and icons ish

### DIFF
--- a/web/ahnlich-web/docs/components/ahnlich-ai/ahnlich-ai.md
+++ b/web/ahnlich-web/docs/components/ahnlich-ai/ahnlich-ai.md
@@ -1,5 +1,5 @@
 ---
-title: Ahnlich AI
+title: 🤖 Ahnlich AI
 sidebar_position: 30
 ---
 

--- a/web/ahnlich-web/docs/components/ahnlich-cli/ahnlich-cli.md
+++ b/web/ahnlich-web/docs/components/ahnlich-cli/ahnlich-cli.md
@@ -1,5 +1,5 @@
 ---
-title: Ahnlich DB
+title: 📟 Ahnlich CLI
 sidebar_position: 10
 ---
 

--- a/web/ahnlich-web/docs/components/ahnlich-db/ahnlich-db.md
+++ b/web/ahnlich-web/docs/components/ahnlich-db/ahnlich-db.md
@@ -1,5 +1,5 @@
 ---
-title: Ahnlich DB
+title: 🗄️ Ahnlich DB
 sidebar_position: 10
 ---
 

--- a/web/ahnlich-web/docs/components/components.md
+++ b/web/ahnlich-web/docs/components/components.md
@@ -1,5 +1,5 @@
 ---
-title: Components
+title: 🧩 Components
 sidebar_position: 30
 ---
 

--- a/web/ahnlich-web/docs/getting-started/comparison-with-other-tools.md
+++ b/web/ahnlich-web/docs/getting-started/comparison-with-other-tools.md
@@ -1,5 +1,5 @@
 ---
-title: Comparison with other tools
+title: ⚖️ Comparison with other tools
 sidebar_position: 30
 ---
 

--- a/web/ahnlich-web/docs/getting-started/getting-started.md
+++ b/web/ahnlich-web/docs/getting-started/getting-started.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 20
-title: Getting started
+title: 🚀 Getting started
 ---
 import DocCardList from '@theme/DocCardList';
 

--- a/web/ahnlich-web/docs/getting-started/installation.md
+++ b/web/ahnlich-web/docs/getting-started/installation.md
@@ -1,5 +1,5 @@
 ---
-title: Installation
+title: 📦 Installation
 sidebar_position: 10
 ---
 

--- a/web/ahnlich-web/docs/getting-started/next-steps.md
+++ b/web/ahnlich-web/docs/getting-started/next-steps.md
@@ -1,5 +1,5 @@
 ---
-title: Next Steps
+title: ➡️ Next Steps
 sidebar_position: 40
 ---
 
@@ -10,6 +10,7 @@ import DocCardList from '@theme/DocCardList';
 <DocCardList items={
     [
         {
+            type: 'link',
             title: 'Architecture',
             label: 'Architecture',
             href: '/docs/architecture',
@@ -17,33 +18,25 @@ import DocCardList from '@theme/DocCardList';
             description: 'Learn about the architecture of Ahnlich'
         },
         {
-            title: 'Quickstart',
-            label: 'Quickstart',
-            href: '/docs/quickstart',
-            docId: 'quickstart',
-            description: 'Get started with Ahnlich'
-        },
-        {
+            type: 'link',
             title: 'Guides',
             label: 'Guides',
             href: '/docs/guides',
-            docId: 'guides',
             description: 'Use cases and examples with Ahnlich'
         },
         {
+            type: 'link',
             title: 'Community',
             label: 'Community',
             href: '/docs/community',
-            docId: 'community',
             description: 'Get involved with Ahnlich'
         },
         {
+            type: 'link',
             title: 'Comparison with other tools',
             label: 'Comparison with other tools',
             href: '/docs/comparison-with-other-tools',
-            docId: 'comparison-with-other-tools',
             description: 'Compare Ahnlich with other tools'
         }
     ]
 } />
-

--- a/web/ahnlich-web/docs/getting-started/usage.md
+++ b/web/ahnlich-web/docs/getting-started/usage.md
@@ -1,5 +1,5 @@
 ---
-title: Usage
+title: 🔨 Usage
 sidebar_position: 20
 ---
 

--- a/web/ahnlich-web/docs/guides/index.md
+++ b/web/ahnlich-web/docs/guides/index.md
@@ -1,5 +1,6 @@
 ---
 sidebar_exclude: true
+slug: /guides
 ---
 
 # Guides

--- a/web/ahnlich-web/docs/index.md
+++ b/web/ahnlich-web/docs/index.md
@@ -1,0 +1,8 @@
+---
+title: Overview
+slug: /
+---
+
+import {Redirect} from '@docusaurus/router';
+
+<Redirect to="/docs/overview" />

--- a/web/ahnlich-web/src/css/custom.css
+++ b/web/ahnlich-web/src/css/custom.css
@@ -37,3 +37,13 @@
   display: flex;
   align-items: center;
 }
+
+.menu__list-item {
+  padding: 0.6rem 0;
+}
+
+.theme-edit-this-page {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}


### PR DESCRIPTION
- Hide the guides section from the sidebar, leaving it on the navbar only. I tried handcrafting the sidebar as opposed to a naive type: autogenerated but it scammed me and started displaying the index page of each category under their respective dropdowns
- Add some padding to each item in the sidebar since they are too close to one another
- Fix the "Edit this page" styling as the icon and text aren't properly aligned
- Ensure that both /docs and /docs/overview renders the Overview page (to avoid users assuming page paths and having 404 errors)
- The "Next steps" page is supposed to render cards, but I haven't figured out the types used by Docusaurus and it just renders my handcrafted object
- Added some icons/emojis as discussed with @deven96... see image for checks, reviews, possible additions or subtractions

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/5de8edde-7ed5-4731-98ec-bda1f9615522" />
