### PR TITLE
Creating groundwork for multiembedding models like insightface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             - name: Get Cargo toolchain
               uses: actions-rs/toolchain@v1
               with:
-                toolchain: 1.88.0
+                toolchain: 1.92.0
 
             - name: Build Linux Release for ${{ needs.prebuild_preparation.outputs.bin_name }}
               working-directory: ./ahnlich

--- a/.github/workflows/rust_tag_and_deploy.yml
+++ b/.github/workflows/rust_tag_and_deploy.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Get Cargo toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88.0
+          toolchain: 1.92.0
 
       - name: Install protoc
         run: |

--- a/ahnlich/ai/src/engine/ai/providers/mod.rs
+++ b/ahnlich/ai/src/engine/ai/providers/mod.rs
@@ -5,19 +5,20 @@ use crate::engine::ai::models::{InputAction, ModelInput};
 use crate::engine::ai::providers::ort::ORTProvider;
 use crate::error::AIProxyError;
 use ahnlich_types::ai::execution_provider::ExecutionProvider;
-use ahnlich_types::keyval::StoreKey;
+
+use super::models::ModelResponse;
 
 pub enum ModelProviders {
     ORT(ORTProvider),
 }
 
 #[async_trait::async_trait]
-pub trait ProviderTrait: Send + Sync {
+pub(crate) trait ProviderTrait: Send + Sync {
     async fn get_model(&self) -> Result<(), AIProxyError>;
     async fn run_inference(
         &self,
         input: ModelInput,
         action_type: &InputAction,
         execution_provider: Option<ExecutionProvider>,
-    ) -> Result<Vec<StoreKey>, AIProxyError>;
+    ) -> Result<Vec<ModelResponse>, AIProxyError>;
 }

--- a/ahnlich/ai/src/engine/ai/providers/processors/mod.rs
+++ b/ahnlich/ai/src/engine/ai/providers/processors/mod.rs
@@ -22,7 +22,7 @@ pub trait Preprocessor: Send + Sync {
 }
 
 pub trait Postprocessor: Send + Sync {
-    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData, AIProxyError>;
+    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData<'_, '_>, AIProxyError>;
 }
 
 pub enum PreprocessorData {

--- a/ahnlich/ai/src/engine/ai/providers/processors/normalize.rs
+++ b/ahnlich/ai/src/engine/ai/providers/processors/normalize.rs
@@ -80,7 +80,7 @@ impl Preprocessor for ImageNormalize {
 pub struct VectorNormalize;
 
 impl Postprocessor for VectorNormalize {
-    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData, AIProxyError> {
+    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData<'_, '_>, AIProxyError> {
         match data {
             PostprocessorData::NdArray2(array) => {
                 let norm = (&array * &array).sum_axis(Axis(1)).sqrt();

--- a/ahnlich/ai/src/engine/ai/providers/processors/onnx_output_transform.rs
+++ b/ahnlich/ai/src/engine/ai/providers/processors/onnx_output_transform.rs
@@ -13,7 +13,7 @@ impl OnnxOutputTransform {
 }
 
 impl Postprocessor for OnnxOutputTransform {
-    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData, AIProxyError> {
+    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData<'_, '_>, AIProxyError> {
         match data {
             PostprocessorData::OnnxOutput(onnx_output) => {
                 let output = onnx_output.get(self.output_key).ok_or_else(|| {

--- a/ahnlich/ai/src/engine/ai/providers/processors/pooling.rs
+++ b/ahnlich/ai/src/engine/ai/providers/processors/pooling.rs
@@ -12,7 +12,7 @@ pub enum Pooling {
 pub struct RegularPooling;
 
 impl Postprocessor for RegularPooling {
-    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData, AIProxyError> {
+    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData<'_, '_>, AIProxyError> {
         match data {
             PostprocessorData::NdArray3(array) => {
                 let processed = array.slice(s![.., 0, ..]).to_owned();
@@ -41,7 +41,7 @@ pub struct MeanPooling {
 }
 
 impl Postprocessor for MeanPooling {
-    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData, AIProxyError> {
+    fn process(&self, data: PostprocessorData) -> Result<PostprocessorData<'_, '_>, AIProxyError> {
         match data {
             PostprocessorData::NdArray3(array) => {
                 let attention_mask = {

--- a/ahnlich/ai/src/error.rs
+++ b/ahnlich/ai/src/error.rs
@@ -115,6 +115,9 @@ pub enum AIProxyError {
     #[error("Error initializing a model thread {0}.")]
     ModelInitializationError(String),
 
+    #[error("Model returned unexpected number of embeddings 0 for input")]
+    ModelInputToEmbeddingError,
+
     #[error("Bytes could not be successfully decoded into an image.")]
     ImageBytesDecodeError,
 
@@ -196,7 +199,8 @@ impl From<AIProxyError> for Status {
             AIProxyError::TokenExceededError {
                 max_token_size: _,
                 input_token_size: _,
-            } => Code::OutOfRange,
+            }
+            | AIProxyError::ModelInputToEmbeddingError => Code::OutOfRange,
             _others => Code::Internal,
         };
         Status::new(code, message)

--- a/ahnlich/ai/src/tests/aiproxy_test.rs
+++ b/ahnlich/ai/src/tests/aiproxy_test.rs
@@ -787,11 +787,11 @@ async fn test_convert_store_input_to_embeddings(index: usize, model: i32) {
 
     // Verify all expected entries are present (order-independent)
     for input in store_inputs {
-        assert!(response_entries.iter().any(|e| {
-            e.input == Some(input.clone())
-                && e.embedding.is_some()
-                && e.embedding.as_ref().unwrap().key.len() > 0
-        }))
+        assert!(
+            response_entries
+                .iter()
+                .any(|e| { e.input == Some(input.clone()) && e.variant.is_some() })
+        )
     }
 }
 
@@ -935,11 +935,11 @@ async fn test_convert_store_input_to_embeddings_without_db(index: usize, model: 
 
     // Verify all expected entries are present (order-independent)
     for input in store_inputs {
-        assert!(response_entries.iter().any(|e| {
-            e.input == Some(input.clone())
-                && e.embedding.is_some()
-                && e.embedding.as_ref().unwrap().key.len() > 0
-        }))
+        assert!(
+            response_entries
+                .iter()
+                .any(|e| { e.input == Some(input.clone()) && e.variant.is_some() })
+        )
     }
 }
 

--- a/ahnlich/client/src/ai.rs
+++ b/ahnlich/client/src/ai.rs
@@ -863,11 +863,11 @@ mod test {
 
         // Verify all expected entries are present (order-independent)
         for input in store_inputs {
-            assert!(response_entries.iter().any(|e| {
-                e.input == Some(input.clone())
-                    && e.embedding.is_some()
-                    && e.embedding.as_ref().unwrap().key.len() > 0
-            }))
+            assert!(
+                response_entries
+                    .iter()
+                    .any(|e| { e.input == Some(input.clone()) && e.variant.is_some() })
+            )
         }
     }
 

--- a/ahnlich/db/src/algorithm/non_linear.rs
+++ b/ahnlich/db/src/algorithm/non_linear.rs
@@ -21,7 +21,7 @@ pub(crate) enum NonLinearAlgorithmWithIndex {
 }
 
 impl NonLinearAlgorithmWithIndex {
-    fn get_inner(&self) -> &impl NonLinearAlgorithmWithIndexImpl {
+    fn get_inner(&self) -> &impl NonLinearAlgorithmWithIndexImpl<'_> {
         match self {
             Self::KDTree(kdtree) => kdtree,
         }

--- a/ahnlich/db/src/server/handler.rs
+++ b/ahnlich/db/src/server/handler.rs
@@ -717,7 +717,7 @@ impl DbService for Server {
 impl AhnlichServerUtils for Server {
     type PersistenceTask = StoreHandler;
 
-    fn config(&self) -> ServerUtilsConfig {
+    fn config(&self) -> ServerUtilsConfig<'_> {
         ServerUtilsConfig {
             service_name: SERVICE_NAME,
             persist_location: &self.config.common.persist_location,

--- a/ahnlich/dsl/src/ai.rs
+++ b/ahnlich/dsl/src/ai.rs
@@ -105,16 +105,16 @@ pub fn parse_ai_query(input: &str) -> Result<Vec<AiQuery>, DslError> {
                 )? as i32;
 
                 let mut execution_provider = None;
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::execution_provider_optional {
-                        let mut pair = inner_pairs
-                            .next()
-                            .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?
-                            .into_inner();
-                        execution_provider = Some(parse_to_execution_provider(
-                            pair.next().map(|a| a.as_str()).unwrap(),
-                        )? as i32);
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::execution_provider_optional
+                {
+                    let mut pair = inner_pairs
+                        .next()
+                        .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?
+                        .into_inner();
+                    execution_provider = Some(parse_to_execution_provider(
+                        pair.next().map(|a| a.as_str()).unwrap(),
+                    )? as i32);
                 };
 
                 AiQuery::Set(Set {
@@ -127,11 +127,11 @@ pub fn parse_ai_query(input: &str) -> Result<Vec<AiQuery>, DslError> {
             Rule::ai_create_store => {
                 let mut inner_pairs = statement.into_inner().peekable();
                 let mut error_if_exists = true;
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::if_not_exists {
-                        inner_pairs.next(); // Consume rule
-                        error_if_exists = false;
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::if_not_exists
+                {
+                    inner_pairs.next(); // Consume rule
+                    error_if_exists = false;
                 };
                 let store = inner_pairs
                     .next()
@@ -151,35 +151,35 @@ pub fn parse_ai_query(input: &str) -> Result<Vec<AiQuery>, DslError> {
                         .as_str(),
                 )? as i32;
                 let mut predicates = Vec::new();
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::metadata_keys {
-                        let index_name_pairs = inner_pairs
-                            .next()
-                            .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
-                        predicates = index_name_pairs
-                            .into_inner()
-                            .map(|index_pair| index_pair.as_str().to_string())
-                            .collect();
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::metadata_keys
+                {
+                    let index_name_pairs = inner_pairs
+                        .next()
+                        .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
+                    predicates = index_name_pairs
+                        .into_inner()
+                        .map(|index_pair| index_pair.as_str().to_string())
+                        .collect();
                 };
                 let mut non_linear_indices = Vec::new();
                 let mut store_original = false;
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::non_linear_algorithms {
-                        let index_name_pairs = inner_pairs
-                            .next()
-                            .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
-                        non_linear_indices = index_name_pairs
-                            .into_inner()
-                            .flat_map(|index_pair| to_non_linear(index_pair.as_str()))
-                            .map(|a| a as i32)
-                            .collect();
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::non_linear_algorithms
+                {
+                    let index_name_pairs = inner_pairs
+                        .next()
+                        .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
+                    non_linear_indices = index_name_pairs
+                        .into_inner()
+                        .flat_map(|index_pair| to_non_linear(index_pair.as_str()))
+                        .map(|a| a as i32)
+                        .collect();
                 };
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::store_original {
-                        store_original = true;
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::store_original
+                {
+                    store_original = true;
                 }
                 AiQuery::CreateStore(CreateStore {
                     store,
@@ -211,27 +211,27 @@ pub fn parse_ai_query(input: &str) -> Result<Vec<AiQuery>, DslError> {
                 )? as i32;
                 let mut preprocess_action = PreprocessAction::NoPreprocessing;
                 let mut execution_provider = None;
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::preprocess_optional {
-                        let mut pair = inner_pairs
-                            .next()
-                            .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?
-                            .into_inner();
-                        preprocess_action = parse_to_preprocess_action(
-                            pair.next().map(|a| a.as_str()).unwrap_or("nopreprocessing"),
-                        )?;
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::preprocess_optional
+                {
+                    let mut pair = inner_pairs
+                        .next()
+                        .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?
+                        .into_inner();
+                    preprocess_action = parse_to_preprocess_action(
+                        pair.next().map(|a| a.as_str()).unwrap_or("nopreprocessing"),
+                    )?;
                 };
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::execution_provider_optional {
-                        let mut pair = inner_pairs
-                            .next()
-                            .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?
-                            .into_inner();
-                        execution_provider = Some(parse_to_execution_provider(
-                            pair.next().map(|a| a.as_str()).unwrap(),
-                        )? as i32);
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::execution_provider_optional
+                {
+                    let mut pair = inner_pairs
+                        .next()
+                        .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?
+                        .into_inner();
+                    execution_provider = Some(parse_to_execution_provider(
+                        pair.next().map(|a| a.as_str()).unwrap(),
+                    )? as i32);
                 };
                 let store = inner_pairs
                     .next()

--- a/ahnlich/dsl/src/db.rs
+++ b/ahnlich/dsl/src/db.rs
@@ -73,11 +73,11 @@ pub fn parse_db_query(input: &str) -> Result<Vec<DBQuery>, DslError> {
             Rule::create_store => {
                 let mut inner_pairs = statement.into_inner().peekable();
                 let mut error_if_exists = true;
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::if_not_exists {
-                        inner_pairs.next(); // Consume rule
-                        error_if_exists = false;
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::if_not_exists
+                {
+                    inner_pairs.next(); // Consume rule
+                    error_if_exists = false;
                 };
                 let store = inner_pairs
                     .next()
@@ -91,29 +91,29 @@ pub fn parse_db_query(input: &str) -> Result<Vec<DBQuery>, DslError> {
                     .parse::<NonZeroUsize>()?
                     .get() as u32;
                 let mut create_predicates = Vec::new();
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::metadata_keys {
-                        let index_name_pairs = inner_pairs
-                            .next()
-                            .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
-                        create_predicates = index_name_pairs
-                            .into_inner()
-                            .map(|index_pair| index_pair.as_str().to_string())
-                            .collect();
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::metadata_keys
+                {
+                    let index_name_pairs = inner_pairs
+                        .next()
+                        .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
+                    create_predicates = index_name_pairs
+                        .into_inner()
+                        .map(|index_pair| index_pair.as_str().to_string())
+                        .collect();
                 };
                 let mut non_linear_indices = Vec::new();
-                if let Some(next_pair) = inner_pairs.peek() {
-                    if next_pair.as_rule() == Rule::non_linear_algorithms {
-                        let index_name_pairs = inner_pairs
-                            .next()
-                            .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
-                        non_linear_indices = index_name_pairs
-                            .into_inner()
-                            .flat_map(|index_pair| to_non_linear(index_pair.as_str()))
-                            .map(|a| a as i32)
-                            .collect();
-                    }
+                if let Some(next_pair) = inner_pairs.peek()
+                    && next_pair.as_rule() == Rule::non_linear_algorithms
+                {
+                    let index_name_pairs = inner_pairs
+                        .next()
+                        .ok_or(DslError::UnexpectedSpan((start_pos, end_pos)))?; // Consume rule
+                    non_linear_indices = index_name_pairs
+                        .into_inner()
+                        .flat_map(|index_pair| to_non_linear(index_pair.as_str()))
+                        .map(|a| a as i32)
+                        .collect();
                 };
                 DBQuery::CreateStore(CreateStore {
                     store,

--- a/ahnlich/dsl/src/shared.rs
+++ b/ahnlich/dsl/src/shared.rs
@@ -40,11 +40,11 @@ pub(crate) fn parse_drop_non_linear_algorithm_index(
             let end_pos = statement.as_span().end_pos().pos();
             let mut inner_pairs = statement.into_inner().peekable();
             let mut if_exists = false;
-            if let Some(next_pair) = inner_pairs.peek() {
-                if next_pair.as_rule() == Rule::if_exists {
-                    inner_pairs.next(); // Consume rule
-                    if_exists = true;
-                }
+            if let Some(next_pair) = inner_pairs.peek()
+                && next_pair.as_rule() == Rule::if_exists
+            {
+                inner_pairs.next(); // Consume rule
+                if_exists = true;
             };
             let index_names_pair = inner_pairs
                 .next()
@@ -73,11 +73,11 @@ pub(crate) fn parse_drop_pred_index(
             let end_pos = statement.as_span().end_pos().pos();
             let mut inner_pairs = statement.into_inner().peekable();
             let mut if_exists = false;
-            if let Some(next_pair) = inner_pairs.peek() {
-                if next_pair.as_rule() == Rule::if_exists {
-                    inner_pairs.next();
-                    if_exists = true;
-                }
+            if let Some(next_pair) = inner_pairs.peek()
+                && next_pair.as_rule() == Rule::if_exists
+            {
+                inner_pairs.next();
+                if_exists = true;
             };
             let index_names_pair = inner_pairs
                 .next()

--- a/ahnlich/rust-toolchain.toml
+++ b/ahnlich/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.92.0"
 components = [ "rustfmt", "clippy" ]

--- a/ahnlich/similarity/src/kdtree.rs
+++ b/ahnlich/similarity/src/kdtree.rs
@@ -454,13 +454,14 @@ impl KDTree {
             let distance = self.squared_distance(reference_point, &shared.point);
             if heap.len() < n.get() && Self::is_in_accept_list(accept_list, &shared.point) {
                 heap.push(Reverse(OrderedArray(shared.point.clone(), distance)));
-            } else if let Some(Reverse(OrderedArray(_, max_distance))) = heap.peek() {
-                if distance < *max_distance && Self::is_in_accept_list(accept_list, &shared.point) {
-                    if heap.len() >= n.get() {
-                        heap.pop();
-                    }
-                    heap.push(Reverse(OrderedArray(shared.point.clone(), distance)));
+            } else if let Some(Reverse(OrderedArray(_, max_distance))) = heap.peek()
+                && distance < *max_distance
+                && Self::is_in_accept_list(accept_list, &shared.point)
+            {
+                if heap.len() >= n.get() {
+                    heap.pop();
                 }
+                heap.push(Reverse(OrderedArray(shared.point.clone(), distance)));
             }
 
             let dim = depth % self.depth.get();

--- a/ahnlich/types/build.rs
+++ b/ahnlich/types/build.rs
@@ -116,38 +116,37 @@ fn restructure_generated_code(out_dir: &PathBuf, file: &mut std::fs::File) {
     let mut module_names = HashSet::new();
 
     for file in &generated_code {
-        if let Some(file_name) = file.file_name().and_then(|n| n.to_str()) {
-            if file_name.contains(".") {
-                let parts: Vec<&str> = file_name.split('.').collect();
-                module_names.insert(parts[0]);
+        if let Some(file_name) = file.file_name().and_then(|n| n.to_str())
+            && file_name.contains(".")
+        {
+            let parts: Vec<&str> = file_name.split('.').collect();
+            module_names.insert(parts[0]);
 
-                if parts.len() > 2 {
-                    let module_name = parts[0];
-                    let struct_file = format!("{}.rs", parts[1]);
+            if parts.len() > 2 {
+                let module_name = parts[0];
+                let struct_file = format!("{}.rs", parts[1]);
 
-                    let module_path = out_dir.join(module_name);
-                    let final_file_path = module_path.join(struct_file);
+                let module_path = out_dir.join(module_name);
+                let final_file_path = module_path.join(struct_file);
 
-                    // create module dir if missing
-                    std::fs::create_dir_all(&module_path)
-                        .expect("Failed to create module directory");
+                // create module dir if missing
+                std::fs::create_dir_all(&module_path).expect("Failed to create module directory");
 
-                    std::fs::rename(file, &final_file_path)
-                        .expect("Failed to move generated file to new location");
+                std::fs::rename(file, &final_file_path)
+                    .expect("Failed to move generated file to new location");
 
-                    let mod_rs_path = module_path.join("mod.rs");
+                let mod_rs_path = module_path.join("mod.rs");
 
-                    let mut file = std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(&mod_rs_path)
-                        .expect("Failed to create mod file");
+                let mut file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&mod_rs_path)
+                    .expect("Failed to create mod file");
 
-                    let buffer = format!("pub mod {};\n", parts[1]);
+                let buffer = format!("pub mod {};\n", parts[1]);
 
-                    file.write_all(buffer.as_bytes())
-                        .expect("Failed to write to mod file");
-                }
+                file.write_all(buffer.as_bytes())
+                    .expect("Failed to write to mod file");
             }
         }
     }

--- a/ahnlich/types/src/ai/server.rs
+++ b/ahnlich/types/src/ai/server.rs
@@ -71,11 +71,26 @@ pub struct AiStoreInfo {
     pub embedding_size: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MultipleEmbedding {
+    #[prost(message, repeated, tag = "1")]
+    pub embeddings: ::prost::alloc::vec::Vec<super::super::keyval::StoreKey>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SingleInputToEmbedding {
     #[prost(message, optional, tag = "1")]
     pub input: ::core::option::Option<super::super::keyval::StoreInput>,
-    #[prost(message, optional, tag = "2")]
-    pub embedding: ::core::option::Option<super::super::keyval::StoreKey>,
+    #[prost(oneof = "single_input_to_embedding::Variant", tags = "2, 3")]
+    pub variant: ::core::option::Option<single_input_to_embedding::Variant>,
+}
+/// Nested message and enum types in `SingleInputToEmbedding`.
+pub mod single_input_to_embedding {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(message, tag = "2")]
+        Multiple(super::MultipleEmbedding),
+        #[prost(message, tag = "3")]
+        Single(super::super::super::keyval::StoreKey),
+    }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StoreInputToEmbeddingsList {

--- a/ahnlich/utils/src/connection_layer.rs
+++ b/ahnlich/utils/src/connection_layer.rs
@@ -7,10 +7,9 @@ pub fn trace_with_parent(req: &http::Request<()>) -> tracing::Span {
         .headers()
         .get(TRACE_HEADER)
         .and_then(|val| val.to_str().ok())
+        && let Ok(parent_context) = tracer::trace_parent_to_span(trace_parent)
     {
-        if let Ok(parent_context) = tracer::trace_parent_to_span(trace_parent) {
-            span.set_parent(parent_context);
-        };
+        span.set_parent(parent_context);
     }
     span
 }

--- a/ahnlich/utils/src/server.rs
+++ b/ahnlich/utils/src/server.rs
@@ -40,7 +40,7 @@ pub struct ServerUtilsConfig<'a> {
 pub trait AhnlichServerUtils: BlockingTask + Sized + Send + Sync + 'static + Debug {
     type PersistenceTask: AhnlichPersistenceUtils;
 
-    fn config(&self) -> ServerUtilsConfig;
+    fn config(&self) -> ServerUtilsConfig<'_>;
 
     fn store_handler(&self) -> &Arc<Self::PersistenceTask>;
     fn write_flag(&self) -> Arc<AtomicBool> {

--- a/protos/ai/server.proto
+++ b/protos/ai/server.proto
@@ -64,9 +64,16 @@ message AIStoreInfo {
   uint64 embedding_size = 4;
 }
 
+message MultipleEmbedding {
+  repeated keyval.StoreKey embeddings = 1;
+}
+
 message SingleInputToEmbedding {
   keyval.StoreInput input = 1;
-  keyval.StoreKey embedding = 2;
+  oneof variant {
+    MultipleEmbedding multiple = 2;
+    keyval.StoreKey single = 3;
+  }
 }
 
 message StoreInputToEmbeddingsList {

--- a/sdk/ahnlich-client-go/grpc/ai/server/server.pb.go
+++ b/sdk/ahnlich-client-go/grpc/ai/server/server.pb.go
@@ -668,19 +668,70 @@ func (x *AIStoreInfo) GetEmbeddingSize() uint64 {
 	return 0
 }
 
+type MultipleEmbedding struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Embeddings []*keyval.StoreKey `protobuf:"bytes,1,rep,name=embeddings,proto3" json:"embeddings,omitempty"`
+}
+
+func (x *MultipleEmbedding) Reset() {
+	*x = MultipleEmbedding{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_ai_server_proto_msgTypes[13]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *MultipleEmbedding) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MultipleEmbedding) ProtoMessage() {}
+
+func (x *MultipleEmbedding) ProtoReflect() protoreflect.Message {
+	mi := &file_ai_server_proto_msgTypes[13]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MultipleEmbedding.ProtoReflect.Descriptor instead.
+func (*MultipleEmbedding) Descriptor() ([]byte, []int) {
+	return file_ai_server_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *MultipleEmbedding) GetEmbeddings() []*keyval.StoreKey {
+	if x != nil {
+		return x.Embeddings
+	}
+	return nil
+}
+
 type SingleInputToEmbedding struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Input     *keyval.StoreInput `protobuf:"bytes,1,opt,name=input,proto3" json:"input,omitempty"`
-	Embedding *keyval.StoreKey   `protobuf:"bytes,2,opt,name=embedding,proto3" json:"embedding,omitempty"`
+	Input *keyval.StoreInput `protobuf:"bytes,1,opt,name=input,proto3" json:"input,omitempty"`
+	// Types that are assignable to Variant:
+	//
+	//	*SingleInputToEmbedding_Multiple
+	//	*SingleInputToEmbedding_Single
+	Variant isSingleInputToEmbedding_Variant `protobuf_oneof:"variant"`
 }
 
 func (x *SingleInputToEmbedding) Reset() {
 	*x = SingleInputToEmbedding{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_ai_server_proto_msgTypes[13]
+		mi := &file_ai_server_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -693,7 +744,7 @@ func (x *SingleInputToEmbedding) String() string {
 func (*SingleInputToEmbedding) ProtoMessage() {}
 
 func (x *SingleInputToEmbedding) ProtoReflect() protoreflect.Message {
-	mi := &file_ai_server_proto_msgTypes[13]
+	mi := &file_ai_server_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -706,7 +757,7 @@ func (x *SingleInputToEmbedding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SingleInputToEmbedding.ProtoReflect.Descriptor instead.
 func (*SingleInputToEmbedding) Descriptor() ([]byte, []int) {
-	return file_ai_server_proto_rawDescGZIP(), []int{13}
+	return file_ai_server_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SingleInputToEmbedding) GetInput() *keyval.StoreInput {
@@ -716,12 +767,42 @@ func (x *SingleInputToEmbedding) GetInput() *keyval.StoreInput {
 	return nil
 }
 
-func (x *SingleInputToEmbedding) GetEmbedding() *keyval.StoreKey {
-	if x != nil {
-		return x.Embedding
+func (m *SingleInputToEmbedding) GetVariant() isSingleInputToEmbedding_Variant {
+	if m != nil {
+		return m.Variant
 	}
 	return nil
 }
+
+func (x *SingleInputToEmbedding) GetMultiple() *MultipleEmbedding {
+	if x, ok := x.GetVariant().(*SingleInputToEmbedding_Multiple); ok {
+		return x.Multiple
+	}
+	return nil
+}
+
+func (x *SingleInputToEmbedding) GetSingle() *keyval.StoreKey {
+	if x, ok := x.GetVariant().(*SingleInputToEmbedding_Single); ok {
+		return x.Single
+	}
+	return nil
+}
+
+type isSingleInputToEmbedding_Variant interface {
+	isSingleInputToEmbedding_Variant()
+}
+
+type SingleInputToEmbedding_Multiple struct {
+	Multiple *MultipleEmbedding `protobuf:"bytes,2,opt,name=multiple,proto3,oneof"`
+}
+
+type SingleInputToEmbedding_Single struct {
+	Single *keyval.StoreKey `protobuf:"bytes,3,opt,name=single,proto3,oneof"`
+}
+
+func (*SingleInputToEmbedding_Multiple) isSingleInputToEmbedding_Variant() {}
+
+func (*SingleInputToEmbedding_Single) isSingleInputToEmbedding_Variant() {}
 
 type StoreInputToEmbeddingsList struct {
 	state         protoimpl.MessageState
@@ -734,7 +815,7 @@ type StoreInputToEmbeddingsList struct {
 func (x *StoreInputToEmbeddingsList) Reset() {
 	*x = StoreInputToEmbeddingsList{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_ai_server_proto_msgTypes[14]
+		mi := &file_ai_server_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -747,7 +828,7 @@ func (x *StoreInputToEmbeddingsList) String() string {
 func (*StoreInputToEmbeddingsList) ProtoMessage() {}
 
 func (x *StoreInputToEmbeddingsList) ProtoReflect() protoreflect.Message {
-	mi := &file_ai_server_proto_msgTypes[14]
+	mi := &file_ai_server_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -760,7 +841,7 @@ func (x *StoreInputToEmbeddingsList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoreInputToEmbeddingsList.ProtoReflect.Descriptor instead.
 func (*StoreInputToEmbeddingsList) Descriptor() ([]byte, []int) {
-	return file_ai_server_proto_rawDescGZIP(), []int{14}
+	return file_ai_server_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *StoreInputToEmbeddingsList) GetValues() []*SingleInputToEmbedding {
@@ -837,24 +918,33 @@ var file_ai_server_proto_rawDesc = []byte{
 	0x64, 0x65, 0x78, 0x4d, 0x6f, 0x64, 0x65, 0x6c, 0x12, 0x25, 0x0a, 0x0e, 0x65, 0x6d, 0x62, 0x65,
 	0x64, 0x64, 0x69, 0x6e, 0x67, 0x5f, 0x73, 0x69, 0x7a, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04,
 	0x52, 0x0d, 0x65, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e, 0x67, 0x53, 0x69, 0x7a, 0x65, 0x22,
-	0x72, 0x0a, 0x16, 0x53, 0x69, 0x6e, 0x67, 0x6c, 0x65, 0x49, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x6f,
-	0x45, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e, 0x67, 0x12, 0x28, 0x0a, 0x05, 0x69, 0x6e, 0x70,
-	0x75, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x12, 0x2e, 0x6b, 0x65, 0x79, 0x76, 0x61,
-	0x6c, 0x2e, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x49, 0x6e, 0x70, 0x75, 0x74, 0x52, 0x05, 0x69, 0x6e,
-	0x70, 0x75, 0x74, 0x12, 0x2e, 0x0a, 0x09, 0x65, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e, 0x67,
-	0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x10, 0x2e, 0x6b, 0x65, 0x79, 0x76, 0x61, 0x6c, 0x2e,
-	0x53, 0x74, 0x6f, 0x72, 0x65, 0x4b, 0x65, 0x79, 0x52, 0x09, 0x65, 0x6d, 0x62, 0x65, 0x64, 0x64,
-	0x69, 0x6e, 0x67, 0x22, 0x57, 0x0a, 0x1a, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x49, 0x6e, 0x70, 0x75,
-	0x74, 0x54, 0x6f, 0x45, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e, 0x67, 0x73, 0x4c, 0x69, 0x73,
-	0x74, 0x12, 0x39, 0x0a, 0x06, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28,
-	0x0b, 0x32, 0x21, 0x2e, 0x61, 0x69, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x53, 0x69,
-	0x6e, 0x67, 0x6c, 0x65, 0x49, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x6f, 0x45, 0x6d, 0x62, 0x65, 0x64,
-	0x64, 0x69, 0x6e, 0x67, 0x52, 0x06, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x48, 0x5a, 0x46,
-	0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x64, 0x65, 0x76, 0x65, 0x6e,
-	0x39, 0x36, 0x2f, 0x61, 0x68, 0x6e, 0x6c, 0x69, 0x63, 0x68, 0x2f, 0x73, 0x64, 0x6b, 0x2f, 0x61,
-	0x68, 0x6e, 0x6c, 0x69, 0x63, 0x68, 0x2d, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x67, 0x6f,
-	0x2f, 0x67, 0x72, 0x70, 0x63, 0x2f, 0x61, 0x69, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x3b,
-	0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x45, 0x0a, 0x11, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x45, 0x6d, 0x62, 0x65, 0x64,
+	0x64, 0x69, 0x6e, 0x67, 0x12, 0x30, 0x0a, 0x0a, 0x65, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e,
+	0x67, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x10, 0x2e, 0x6b, 0x65, 0x79, 0x76, 0x61,
+	0x6c, 0x2e, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x4b, 0x65, 0x79, 0x52, 0x0a, 0x65, 0x6d, 0x62, 0x65,
+	0x64, 0x64, 0x69, 0x6e, 0x67, 0x73, 0x22, 0xb5, 0x01, 0x0a, 0x16, 0x53, 0x69, 0x6e, 0x67, 0x6c,
+	0x65, 0x49, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x6f, 0x45, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e,
+	0x67, 0x12, 0x28, 0x0a, 0x05, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x12, 0x2e, 0x6b, 0x65, 0x79, 0x76, 0x61, 0x6c, 0x2e, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x49,
+	0x6e, 0x70, 0x75, 0x74, 0x52, 0x05, 0x69, 0x6e, 0x70, 0x75, 0x74, 0x12, 0x3a, 0x0a, 0x08, 0x6d,
+	0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e,
+	0x61, 0x69, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x4d, 0x75, 0x6c, 0x74, 0x69, 0x70,
+	0x6c, 0x65, 0x45, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e, 0x67, 0x48, 0x00, 0x52, 0x08, 0x6d,
+	0x75, 0x6c, 0x74, 0x69, 0x70, 0x6c, 0x65, 0x12, 0x2a, 0x0a, 0x06, 0x73, 0x69, 0x6e, 0x67, 0x6c,
+	0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x10, 0x2e, 0x6b, 0x65, 0x79, 0x76, 0x61, 0x6c,
+	0x2e, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x4b, 0x65, 0x79, 0x48, 0x00, 0x52, 0x06, 0x73, 0x69, 0x6e,
+	0x67, 0x6c, 0x65, 0x42, 0x09, 0x0a, 0x07, 0x76, 0x61, 0x72, 0x69, 0x61, 0x6e, 0x74, 0x22, 0x57,
+	0x0a, 0x1a, 0x53, 0x74, 0x6f, 0x72, 0x65, 0x49, 0x6e, 0x70, 0x75, 0x74, 0x54, 0x6f, 0x45, 0x6d,
+	0x62, 0x65, 0x64, 0x64, 0x69, 0x6e, 0x67, 0x73, 0x4c, 0x69, 0x73, 0x74, 0x12, 0x39, 0x0a, 0x06,
+	0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x21, 0x2e, 0x61,
+	0x69, 0x2e, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x2e, 0x53, 0x69, 0x6e, 0x67, 0x6c, 0x65, 0x49,
+	0x6e, 0x70, 0x75, 0x74, 0x54, 0x6f, 0x45, 0x6d, 0x62, 0x65, 0x64, 0x64, 0x69, 0x6e, 0x67, 0x52,
+	0x06, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x73, 0x42, 0x48, 0x5a, 0x46, 0x67, 0x69, 0x74, 0x68, 0x75,
+	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x64, 0x65, 0x76, 0x65, 0x6e, 0x39, 0x36, 0x2f, 0x61, 0x68,
+	0x6e, 0x6c, 0x69, 0x63, 0x68, 0x2f, 0x73, 0x64, 0x6b, 0x2f, 0x61, 0x68, 0x6e, 0x6c, 0x69, 0x63,
+	0x68, 0x2d, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x67, 0x6f, 0x2f, 0x67, 0x72, 0x70, 0x63,
+	0x2f, 0x61, 0x69, 0x2f, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x3b, 0x73, 0x65, 0x72, 0x76, 0x65,
+	0x72, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -869,7 +959,7 @@ func file_ai_server_proto_rawDescGZIP() []byte {
 	return file_ai_server_proto_rawDescData
 }
 
-var file_ai_server_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_ai_server_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_ai_server_proto_goTypes = []any{
 	(*Unit)(nil),                       // 0: ai.server.Unit
 	(*Pong)(nil),                       // 1: ai.server.Pong
@@ -884,39 +974,42 @@ var file_ai_server_proto_goTypes = []any{
 	(*Del)(nil),                        // 10: ai.server.Del
 	(*CreateIndex)(nil),                // 11: ai.server.CreateIndex
 	(*AIStoreInfo)(nil),                // 12: ai.server.AIStoreInfo
-	(*SingleInputToEmbedding)(nil),     // 13: ai.server.SingleInputToEmbedding
-	(*StoreInputToEmbeddingsList)(nil), // 14: ai.server.StoreInputToEmbeddingsList
-	(*client.ConnectedClient)(nil),     // 15: client.ConnectedClient
-	(*info.ServerInfo)(nil),            // 16: shared.info.ServerInfo
-	(*info.StoreUpsert)(nil),           // 17: shared.info.StoreUpsert
-	(*keyval.StoreInput)(nil),          // 18: keyval.StoreInput
-	(*keyval.StoreValue)(nil),          // 19: keyval.StoreValue
-	(*similarity.Similarity)(nil),      // 20: similarity.Similarity
-	(models.AIModel)(0),                // 21: ai.models.AIModel
-	(*keyval.StoreKey)(nil),            // 22: keyval.StoreKey
+	(*MultipleEmbedding)(nil),          // 13: ai.server.MultipleEmbedding
+	(*SingleInputToEmbedding)(nil),     // 14: ai.server.SingleInputToEmbedding
+	(*StoreInputToEmbeddingsList)(nil), // 15: ai.server.StoreInputToEmbeddingsList
+	(*client.ConnectedClient)(nil),     // 16: client.ConnectedClient
+	(*info.ServerInfo)(nil),            // 17: shared.info.ServerInfo
+	(*info.StoreUpsert)(nil),           // 18: shared.info.StoreUpsert
+	(*keyval.StoreInput)(nil),          // 19: keyval.StoreInput
+	(*keyval.StoreValue)(nil),          // 20: keyval.StoreValue
+	(*similarity.Similarity)(nil),      // 21: similarity.Similarity
+	(models.AIModel)(0),                // 22: ai.models.AIModel
+	(*keyval.StoreKey)(nil),            // 23: keyval.StoreKey
 }
 var file_ai_server_proto_depIdxs = []int32{
-	15, // 0: ai.server.ClientList.clients:type_name -> client.ConnectedClient
+	16, // 0: ai.server.ClientList.clients:type_name -> client.ConnectedClient
 	12, // 1: ai.server.StoreList.stores:type_name -> ai.server.AIStoreInfo
-	16, // 2: ai.server.InfoServer.info:type_name -> shared.info.ServerInfo
-	17, // 3: ai.server.Set.upsert:type_name -> shared.info.StoreUpsert
-	18, // 4: ai.server.GetEntry.key:type_name -> keyval.StoreInput
-	19, // 5: ai.server.GetEntry.value:type_name -> keyval.StoreValue
+	17, // 2: ai.server.InfoServer.info:type_name -> shared.info.ServerInfo
+	18, // 3: ai.server.Set.upsert:type_name -> shared.info.StoreUpsert
+	19, // 4: ai.server.GetEntry.key:type_name -> keyval.StoreInput
+	20, // 5: ai.server.GetEntry.value:type_name -> keyval.StoreValue
 	6,  // 6: ai.server.Get.entries:type_name -> ai.server.GetEntry
-	18, // 7: ai.server.GetSimNEntry.key:type_name -> keyval.StoreInput
-	19, // 8: ai.server.GetSimNEntry.value:type_name -> keyval.StoreValue
-	20, // 9: ai.server.GetSimNEntry.similarity:type_name -> similarity.Similarity
+	19, // 7: ai.server.GetSimNEntry.key:type_name -> keyval.StoreInput
+	20, // 8: ai.server.GetSimNEntry.value:type_name -> keyval.StoreValue
+	21, // 9: ai.server.GetSimNEntry.similarity:type_name -> similarity.Similarity
 	8,  // 10: ai.server.GetSimN.entries:type_name -> ai.server.GetSimNEntry
-	21, // 11: ai.server.AIStoreInfo.query_model:type_name -> ai.models.AIModel
-	21, // 12: ai.server.AIStoreInfo.index_model:type_name -> ai.models.AIModel
-	18, // 13: ai.server.SingleInputToEmbedding.input:type_name -> keyval.StoreInput
-	22, // 14: ai.server.SingleInputToEmbedding.embedding:type_name -> keyval.StoreKey
-	13, // 15: ai.server.StoreInputToEmbeddingsList.values:type_name -> ai.server.SingleInputToEmbedding
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	22, // 11: ai.server.AIStoreInfo.query_model:type_name -> ai.models.AIModel
+	22, // 12: ai.server.AIStoreInfo.index_model:type_name -> ai.models.AIModel
+	23, // 13: ai.server.MultipleEmbedding.embeddings:type_name -> keyval.StoreKey
+	19, // 14: ai.server.SingleInputToEmbedding.input:type_name -> keyval.StoreInput
+	13, // 15: ai.server.SingleInputToEmbedding.multiple:type_name -> ai.server.MultipleEmbedding
+	23, // 16: ai.server.SingleInputToEmbedding.single:type_name -> keyval.StoreKey
+	14, // 17: ai.server.StoreInputToEmbeddingsList.values:type_name -> ai.server.SingleInputToEmbedding
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_ai_server_proto_init() }
@@ -1082,7 +1175,7 @@ func file_ai_server_proto_init() {
 			}
 		}
 		file_ai_server_proto_msgTypes[13].Exporter = func(v any, i int) any {
-			switch v := v.(*SingleInputToEmbedding); i {
+			switch v := v.(*MultipleEmbedding); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1094,6 +1187,18 @@ func file_ai_server_proto_init() {
 			}
 		}
 		file_ai_server_proto_msgTypes[14].Exporter = func(v any, i int) any {
+			switch v := v.(*SingleInputToEmbedding); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_ai_server_proto_msgTypes[15].Exporter = func(v any, i int) any {
 			switch v := v.(*StoreInputToEmbeddingsList); i {
 			case 0:
 				return &v.state
@@ -1107,13 +1212,17 @@ func file_ai_server_proto_init() {
 		}
 	}
 	file_ai_server_proto_msgTypes[8].OneofWrappers = []any{}
+	file_ai_server_proto_msgTypes[14].OneofWrappers = []any{
+		(*SingleInputToEmbedding_Multiple)(nil),
+		(*SingleInputToEmbedding_Single)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_ai_server_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/sdk/ahnlich-client-go/tests/ai/ai_test.go
+++ b/sdk/ahnlich-client-go/tests/ai/ai_test.go
@@ -266,8 +266,8 @@ func TestConvertInputsToEmbeddings(t *testing.T) {
 
 			if okInputToEmbedding && okInput &&
 				rawStringInputToEmbedding.RawString == rawStringInput.RawString &&
-				inputToEmbedding.Embedding != nil &&
-				len(inputToEmbedding.Embedding.Key) > 0 {
+				inputToEmbedding.GetSingle() != nil &&
+				len(inputToEmbedding.GetSingle().Key) > 0 {
 				found = true
 				break
 			}

--- a/sdk/ahnlich-client-py/ahnlich_client_py/grpc/ai/server/__init__.py
+++ b/sdk/ahnlich-client-py/ahnlich_client_py/grpc/ai/server/__init__.py
@@ -87,9 +87,15 @@ class AiStoreInfo(betterproto.Message):
 
 
 @dataclass(eq=False, repr=False)
+class MultipleEmbedding(betterproto.Message):
+    embeddings: List["__keyval__.StoreKey"] = betterproto.message_field(1)
+
+
+@dataclass(eq=False, repr=False)
 class SingleInputToEmbedding(betterproto.Message):
     input: "__keyval__.StoreInput" = betterproto.message_field(1)
-    embedding: "__keyval__.StoreKey" = betterproto.message_field(2)
+    multiple: "MultipleEmbedding" = betterproto.message_field(2, group="variant")
+    single: "__keyval__.StoreKey" = betterproto.message_field(3, group="variant")
 
 
 @dataclass(eq=False, repr=False)

--- a/sdk/ahnlich-client-py/ahnlich_client_py/tests/ai_client/test_ai_client_store_commands.py
+++ b/sdk/ahnlich-client-py/ahnlich_client_py/tests/ai_client/test_ai_client_store_commands.py
@@ -351,9 +351,7 @@ async def test_ai_client_convert_store_input_to_embeddings_succeeds(spin_up_ahnl
 
         for input in inputs:
             assert any(
-                e.input == input
-                and e.embedding is not None
-                and len(e.embedding.key) > 0
+                e.input == input and e.single is not None and len(e.single.key) > 0
                 for e in response.values
             )
     finally:


### PR DESCRIPTION
related to #227 

- Introduced the `ModelResponse` type which splits between models that return one output for one input and models that return multiple output for one input
- Upgraded Rust to 1.92.0
- Fixed `SingleInputToEmbedding` to reflect the fact that embeddings returned can be multiples