### PR TITLE
Add conservative memory checks on hot paths

### DIFF
--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -732,6 +732,11 @@ impl AiService for AIProxyServer {
         request: tonic::Request<AiRequestPipeline>,
     ) -> Result<tonic::Response<AiResponsePipeline>, tonic::Status> {
         let params = request.into_inner();
+
+        let estimated_bytes = params.queries.len() * 1024;
+        utils::allocator::check_memory_available(estimated_bytes)
+            .map_err(|e| AIProxyError::Allocation(e.into()))?;
+
         let mut response_vec = Vec::with_capacity(params.queries.len());
 
         for pipeline_query in params.queries {

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -682,6 +682,15 @@ impl Store {
         }
         let store_dimension: usize = self.dimension.into();
 
+        let entry_size = size_of_val(&StoreKey {
+            key: vec![0.0; store_dimension],
+        }) + size_of_val(&StoreValue {
+            value: StdHashMap::new(),
+        }) + 64;
+        let estimated_bytes = new.len() * entry_size * 3;
+        utils::allocator::check_memory_available(estimated_bytes)
+            .map_err(|e| ServerError::Allocation(e.into()))?;
+
         // Validate dimensions and wrap in Arc immediately - single allocation per entry
         let check_and_wrap = |(store_key, store_val): (StoreKey, StoreValue)| -> Result<
             (StoreKeyId, Arc<StoreKey>, Arc<StoreValue>),


### PR DESCRIPTION
Run pre-allocation checks before heavy operations to enforce allocator limits gracefully instead of panicking.

It's not perfect and a lot of them are very conservative estimates but it is the best we can do without getting rid of `rayon` as it's vector `collect` does not support infallibility (perhaps @Iamdavidonuh can contribute that to them)