### PR TITLE
Add enable_mmap configuration parameter for persistence loading

### DIFF
--- a/ahnlich/Cargo.lock
+++ b/ahnlich/Cargo.lock
@@ -2458,6 +2458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5110,6 +5119,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "log",
+ "memmap2",
  "opentelemetry",
  "papaya",
  "pin-project",

--- a/ahnlich/ai/src/cli/server.rs
+++ b/ahnlich/ai/src/cli/server.rs
@@ -268,6 +268,11 @@ impl AIProxyConfig {
         self.db_auth_key = Some(api_key);
         self
     }
+
+    pub fn disable_mmap(mut self) -> Self {
+        self.common.enable_mmap = false;
+        self
+    }
 }
 
 impl fmt::Display for SupportedModels {

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -1193,6 +1193,7 @@ impl AhnlichServerUtils for AIProxyServer {
             service_name: SERVICE_NAME,
             persist_location: &self.config.common.persist_location,
             persistence_interval: self.config.common.persistence_interval,
+            enable_mmap: self.config.common.enable_mmap,
             size_calculation_interval: 0, // Not used by AI - only DB calculates sizes
             allocator_size: self.config.common.allocator_size,
             threadpool_size: self.config.common.threadpool_size,
@@ -1265,7 +1266,7 @@ impl AIProxyServer {
         let mut store_handler =
             AIStoreHandler::new(write_flag.clone(), config.supported_models.clone());
         if let Some(ref persist_location) = config.common.persist_location {
-            match Persistence::load_snapshot(persist_location) {
+            match Persistence::load_snapshot(persist_location, config.common.enable_mmap) {
                 Err(e) => {
                     log::error!("Failed to load snapshot from persist location {e}");
                     if config.common.fail_on_startup_if_persist_load_fails {

--- a/ahnlich/db/src/cli/server.rs
+++ b/ahnlich/db/src/cli/server.rs
@@ -71,4 +71,9 @@ impl ServerConfig {
         self.common.tls_key = Some(tls_key);
         self
     }
+
+    pub fn disable_mmap(mut self) -> Self {
+        self.common.enable_mmap = false;
+        self
+    }
 }

--- a/ahnlich/db/src/server/handler.rs
+++ b/ahnlich/db/src/server/handler.rs
@@ -769,6 +769,7 @@ impl AhnlichServerUtils for Server {
             service_name: SERVICE_NAME,
             persist_location: &self.config.common.persist_location,
             persistence_interval: self.config.common.persistence_interval,
+            enable_mmap: self.config.common.enable_mmap,
             size_calculation_interval: self.config.common.size_calculation_interval,
             allocator_size: self.config.common.allocator_size,
             threadpool_size: self.config.common.threadpool_size,
@@ -816,7 +817,7 @@ impl Server {
         let write_flag = Arc::new(AtomicBool::new(false));
         let mut store_handler = StoreHandler::new(write_flag.clone());
         if let Some(persist_location) = &config.common.persist_location {
-            match Persistence::load_snapshot(persist_location) {
+            match Persistence::load_snapshot(persist_location, config.common.enable_mmap) {
                 Err(e) => {
                     log::error!("Failed to load snapshot from persist location {e}");
                     if config.common.fail_on_startup_if_persist_load_fails {

--- a/ahnlich/db/src/tests/server_tests.rs
+++ b/ahnlich/db/src/tests/server_tests.rs
@@ -4305,3 +4305,219 @@ async fn test_get_store_in_pipeline() {
         responses[2]
     );
 }
+
+#[tokio::test]
+async fn test_mmap_persistence_performance() {
+    use std::time::Instant;
+
+    let mmap_file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ahnlich_mmap_test.dat");
+    let no_mmap_file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ahnlich_no_mmap_test.dat");
+
+    let _ = std::fs::remove_file(&mmap_file);
+    let _ = std::fs::remove_file(&no_mmap_file);
+
+    // Create a large store with lots of vectors to ensure file > 64KB threshold
+    // Vector dimension: 128, Number of vectors: 1000 = ~500KB file
+    let dimension = 128;
+    let num_vectors = 1000;
+
+    // First, create and persist a large store
+    let config_with_mmap = ServerConfig::default()
+        .os_select_port()
+        .persistence_interval(200)
+        .persist_location(mmap_file.clone());
+
+    let server = Server::new(&config_with_mmap)
+        .await
+        .expect("Failed to create server");
+    let write_flag = server.write_flag();
+    let address = server.local_addr().expect("Could not get local addr");
+
+    tokio::spawn(async move { server.start().await });
+
+    let address = format!("http://{}", address);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let channel = Channel::from_shared(address).expect("Failed to get channel");
+    let mut client = DbServiceClient::connect(channel)
+        .await
+        .expect("Failed to connect");
+
+    // Create store
+    let create_query = db_pipeline::DbQuery {
+        query: Some(Query::CreateStore(db_query_types::CreateStore {
+            store: "LargeStore".to_string(),
+            dimension,
+            create_predicates: vec![],
+            non_linear_indices: vec![],
+            error_if_exists: false,
+        })),
+    };
+
+    client
+        .pipeline(tonic::Request::new(db_pipeline::DbRequestPipeline {
+            queries: vec![create_query],
+        }))
+        .await
+        .expect("Failed to create store");
+
+    // Insert many vectors in batches to create a large file
+    let batch_size = 100;
+    for batch_start in (0..num_vectors).step_by(batch_size) {
+        let batch_end = (batch_start + batch_size).min(num_vectors);
+        let mut inputs = Vec::new();
+
+        for i in batch_start..batch_end {
+            let key: Vec<f32> = (0..dimension)
+                .map(|j| ((i * dimension as usize + j as usize) as f32) * 0.01)
+                .collect();
+            inputs.push(DbStoreEntry {
+                key: Some(StoreKey { key }),
+                value: Some(StoreValue {
+                    value: HashMap::new(),
+                }),
+            });
+        }
+
+        let set_query = db_pipeline::DbQuery {
+            query: Some(Query::Set(db_query_types::Set {
+                store: "LargeStore".into(),
+                inputs,
+            })),
+        };
+
+        client
+            .pipeline(tonic::Request::new(db_pipeline::DbRequestPipeline {
+                queries: vec![set_query],
+            }))
+            .await
+            .expect("Failed to insert batch");
+    }
+
+    // Trigger persistence by setting write flag and waiting
+    write_flag.store(true, Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Verify the file was created and check its size
+    let file_metadata = std::fs::metadata(&mmap_file).expect("Persistence file not created");
+    let file_size_kb = file_metadata.len() / 1024;
+    println!(
+        "Persistence file size: {} KB ({} bytes)",
+        file_size_kb,
+        file_metadata.len()
+    );
+
+    // The file should be larger than the mmap threshold (64KB)
+    assert!(
+        file_metadata.len() > 64 * 1024,
+        "File size ({} bytes) should be > 64KB for meaningful mmap test",
+        file_metadata.len()
+    );
+
+    // Copy the file for the no-mmap test
+    std::fs::copy(&mmap_file, &no_mmap_file).expect("Failed to copy persistence file");
+
+    // Now test loading with mmap enabled (default)
+    let config_with_mmap = ServerConfig::default()
+        .os_select_port()
+        .persist_location(mmap_file.clone());
+
+    let start = Instant::now();
+    let server_mmap = Server::new(&config_with_mmap)
+        .await
+        .expect("Failed to create server with mmap");
+    let mmap_duration = start.elapsed();
+
+    // Verify the store was loaded correctly
+    let address = server_mmap.local_addr().expect("Could not get local addr");
+    tokio::spawn(async move { server_mmap.start().await });
+
+    let address = format!("http://{}", address);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let channel = Channel::from_shared(address).expect("Failed to get channel");
+    let mut client_mmap = DbServiceClient::connect(channel)
+        .await
+        .expect("Failed to connect");
+
+    let list_query = db_pipeline::DbQuery {
+        query: Some(Query::ListStores(db_query_types::ListStores {})),
+    };
+
+    let response = client_mmap
+        .pipeline(tonic::Request::new(db_pipeline::DbRequestPipeline {
+            queries: vec![list_query],
+        }))
+        .await
+        .expect("Failed to list stores");
+
+    // Verify store exists
+    let responses = response.into_inner().responses;
+    assert_eq!(responses.len(), 1);
+    if let Some(db_pipeline::db_server_response::Response::StoreList(store_list)) =
+        &responses[0].response
+    {
+        assert_eq!(store_list.stores.len(), 1);
+        assert_eq!(store_list.stores[0].name, "LargeStore");
+    } else {
+        panic!("Expected StoreList response");
+    }
+
+    // Now test loading with mmap disabled
+    let config_no_mmap = ServerConfig::default()
+        .os_select_port()
+        .persist_location(no_mmap_file.clone())
+        .disable_mmap(); // This is a new method we need to add
+
+    let start = Instant::now();
+    let server_no_mmap = Server::new(&config_no_mmap)
+        .await
+        .expect("Failed to create server without mmap");
+    let no_mmap_duration = start.elapsed();
+
+    // Verify the store was loaded correctly
+    let address = server_no_mmap
+        .local_addr()
+        .expect("Could not get local addr");
+    tokio::spawn(async move { server_no_mmap.start().await });
+
+    let address = format!("http://{}", address);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let channel = Channel::from_shared(address).expect("Failed to get channel");
+    let mut client_no_mmap = DbServiceClient::connect(channel)
+        .await
+        .expect("Failed to connect");
+
+    let list_query = db_pipeline::DbQuery {
+        query: Some(Query::ListStores(db_query_types::ListStores {})),
+    };
+
+    let response = client_no_mmap
+        .pipeline(tonic::Request::new(db_pipeline::DbRequestPipeline {
+            queries: vec![list_query],
+        }))
+        .await
+        .expect("Failed to list stores");
+
+    // Verify store exists
+    let responses = response.into_inner().responses;
+    assert_eq!(responses.len(), 1);
+    if let Some(db_pipeline::db_server_response::Response::StoreList(store_list)) =
+        &responses[0].response
+    {
+        assert_eq!(store_list.stores.len(), 1);
+        assert_eq!(store_list.stores[0].name, "LargeStore");
+    } else {
+        panic!("Expected StoreList response");
+    }
+
+    assert!(
+        mmap_duration < no_mmap_duration,
+        "Mmap should be strictly faster than buffered reading for large files. File: {} KB, mmap: {:?}, no mmap: {:?}",
+        file_size_kb,
+        mmap_duration,
+        no_mmap_duration
+    );
+
+    // Clean up
+    let _ = std::fs::remove_file(&mmap_file);
+    let _ = std::fs::remove_file(&no_mmap_file);
+}

--- a/ahnlich/utils/Cargo.toml
+++ b/ahnlich/utils/Cargo.toml
@@ -36,3 +36,4 @@ http.workspace = true
 hyper = { version = "1", features = ["full"] }
 sha2 = "0.10"
 toml = "0.8"
+memmap2 = "0.9.10"

--- a/ahnlich/utils/src/cli.rs
+++ b/ahnlich/utils/src/cli.rs
@@ -92,6 +92,13 @@ pub struct CommandLineConfig {
     #[arg(long, default_value_t =
     DEFAULT_CONFIG.get_or_init(CommandLineConfig::default).size_calculation_interval.clone())]
     pub size_calculation_interval: u64,
+
+    /// Enable memory-mapped I/O for persistence loading
+    /// When enabled, large persistence files (>64KB) are loaded using mmap for better performance
+    /// Defaults to true when persistence is enabled
+    #[arg(long, default_value_t =
+    DEFAULT_CONFIG.get_or_init(CommandLineConfig::default).enable_mmap.clone())]
+    pub enable_mmap: bool,
 }
 
 impl Default for CommandLineConfig {
@@ -114,6 +121,7 @@ impl Default for CommandLineConfig {
             tls_cert: None,
             tls_key: None,
             size_calculation_interval: 60,
+            enable_mmap: true, // Default to true for better performance
         }
     }
 }

--- a/ahnlich/utils/src/persistence.rs
+++ b/ahnlich/utils/src/persistence.rs
@@ -1,10 +1,13 @@
+use memmap2::Mmap;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::BufReader;
+use std::io::BufWriter;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -14,6 +17,8 @@ use tempfile::NamedTempFile;
 use thiserror::Error;
 use tokio::time::Duration;
 use tokio::time::sleep;
+
+const MMAP_THRESHOLD: u64 = 64 * 1024; // 64KB
 
 pub trait AhnlichPersistenceUtils {
     type PersistenceObject: Serialize + DeserializeOwned + Send + Sync + 'static + Debug;
@@ -41,8 +46,8 @@ pub enum PersistenceTaskError {
 pub struct Persistence<T> {
     write_flag: Arc<AtomicBool>,
     persistence_interval: u64,
-    persist_location: std::path::PathBuf,
     persist_object: T,
+    persist_location: PathBuf,
 }
 
 #[async_trait::async_trait]
@@ -55,28 +60,31 @@ impl<T: Sync + Serialize + DeserializeOwned + Debug> Task for Persistence<T> {
         if self.has_potential_write().await {
             log::debug!("In potential write");
             let persist_location: &Path = self.persist_location.as_ref();
-            let writer = if let Ok(file) = NamedTempFile::new_in(
+            let writer = match NamedTempFile::new_in(
                 persist_location
                     .parent()
                     .expect("Could not get parent directory of persist location"),
             ) {
-                file
-            } else {
-                log::error!("Could not create persistence file, skipping");
-                return TaskState::Continue;
+                Ok(file) => file,
+                Err(e) => {
+                    log::error!("Could not create persistence file with err {e:?}, skipping");
+                    return TaskState::Continue;
+                }
             };
-            let temp_path = writer.path();
             // set write flag to false before writing to it
             let _ =
                 self.write_flag
                     .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst);
-            if let Err(e) = serde_json::to_writer(&writer, &self.persist_object) {
-                log::error!("Error writing stores to temp file {e:?}");
-            } else {
-                match std::fs::rename(temp_path, persist_location) {
-                    Ok(_) => log::debug!("Persisted stores to disk"),
-                    Err(e) => log::error!("Error writing temp file to persist location {e}"),
-                };
+            {
+                let buf_writer = BufWriter::new(&writer);
+                if let Err(e) = serde_json::to_writer(buf_writer, &self.persist_object) {
+                    log::error!("Error writing stores to temp file {e:?}");
+                    return TaskState::Continue;
+                }
+            }
+            match writer.persist(persist_location) {
+                Ok(_) => log::debug!("Persisted stores to disk"),
+                Err(e) => log::error!("Error persisting temp file to location {e}"),
             }
         }
         TaskState::Continue
@@ -84,11 +92,28 @@ impl<T: Sync + Serialize + DeserializeOwned + Debug> Task for Persistence<T> {
 }
 
 impl<T: Serialize + DeserializeOwned> Persistence<T> {
-    pub fn load_snapshot(persist_location: &std::path::PathBuf) -> Result<T, PersistenceTaskError> {
+    pub fn load_snapshot(
+        persist_location: &std::path::PathBuf,
+        enable_mmap: bool,
+    ) -> Result<T, PersistenceTaskError> {
         let file = File::open(persist_location)?;
-        let reader = BufReader::new(file);
-        let loaded: T = serde_json::from_reader(reader)?;
-        Ok(loaded)
+        let file_size = file.metadata()?.len();
+
+        Ok(if enable_mmap && file_size > MMAP_THRESHOLD {
+            log::debug!(
+                "Using mmap to load persistence file (size: {} bytes)",
+                file_size
+            );
+            let mmap = unsafe { Mmap::map(&file)? };
+            serde_json::from_slice(&mmap)?
+        } else {
+            log::debug!(
+                "Using buffered reader to load persistence file (size: {} bytes)",
+                file_size
+            );
+            let reader = BufReader::new(file);
+            serde_json::from_reader(reader)?
+        })
     }
 
     pub fn task(
@@ -96,6 +121,7 @@ impl<T: Serialize + DeserializeOwned> Persistence<T> {
         persistence_interval: u64,
         persist_location: &std::path::PathBuf,
         persist_object: T,
+        _enable_mmap: bool,
     ) -> Self {
         let _ = OpenOptions::new()
             .append(true)

--- a/ahnlich/utils/src/server.rs
+++ b/ahnlich/utils/src/server.rs
@@ -32,6 +32,7 @@ pub struct ServerUtilsConfig<'a> {
     // persistence stuff
     pub persistence_interval: u64,
     pub persist_location: &'a Option<std::path::PathBuf>,
+    pub enable_mmap: bool,
     // size calculation stuff
     pub size_calculation_interval: u64,
     // global allocator
@@ -98,6 +99,7 @@ pub trait AhnlichServerUtils: BlockingTask + Sized + Send + Sync + 'static + Deb
                 self.config().persistence_interval,
                 persist_location,
                 self.store_handler().get_snapshot(),
+                self.config().enable_mmap,
             );
             task_manager.spawn_task_loop(persistence_task).await;
         };


### PR DESCRIPTION
Add --enable-mmap CLI flag (defaults to true) to control memory-mapped I/O for loading persistence files. Files >64KB use mmap for better performance, smaller files use buffered reader. Includes integration test showing some speedup on large files.

Included BufWriter for buffering file writing as well