### PR TITLE
fix: `AiService.drop_store()` and `AiService.purge_stores()` do not delete the underlying store from ahnlich-db (#326)

### DIFF
--- a/ahnlich/ai/src/engine/store.rs
+++ b/ahnlich/ai/src/engine/store.rs
@@ -446,6 +446,9 @@ impl AIStoreHandler {
         let store_length = self.stores.pin().len();
         let guard = self.stores.guard();
         self.stores.clear(&guard);
+        if store_length > 0 {
+            self.set_write_flag();
+        }
         store_length
     }
 }

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -58,6 +58,7 @@ use ahnlich_types::db::query::CreateStore as DbCreateStore;
 use ahnlich_types::db::query::DelPred;
 use ahnlich_types::db::query::DropNonLinearAlgorithmIndex as DbDropNonLinearAlgorithmIndex;
 use ahnlich_types::db::query::DropPredIndex as DbDropPredIndex;
+use ahnlich_types::db::query::DropStore as DbDropStore;
 use ahnlich_types::db::query::GetPred as DbGetPred;
 use ahnlich_types::db::query::GetSimN as DbGetSimN;
 use ahnlich_types::db::server::Set as DbSet;
@@ -696,12 +697,30 @@ impl AiService for AIProxyServer {
         request: tonic::Request<DropStore>,
     ) -> Result<tonic::Response<Del>, tonic::Status> {
         let drop_store_params = request.into_inner();
-        let dropped = self.store_handler.drop_store(
-            StoreName {
-                value: drop_store_params.store,
-            },
-            drop_store_params.error_if_not_exists,
-        )?;
+
+        let store_name = StoreName {
+            value: drop_store_params.store,
+        };
+
+        if let Ok(_) = self.store_handler.get(&store_name)
+            && let Some(db_client) = &self.db_client
+        {
+            let parent_id = tracer::span_to_trace_parent(tracing::Span::current());
+            db_client
+                .drop_store(
+                    DbDropStore {
+                        store: store_name.value.clone(),
+                        error_if_not_exists: drop_store_params.error_if_not_exists,
+                    },
+                    parent_id,
+                )
+                .await?;
+        }
+
+        let dropped = self
+            .store_handler
+            .drop_store(store_name, drop_store_params.error_if_not_exists)?;
+
         Ok(tonic::Response::new(Del {
             deleted_count: dropped as u64,
         }))
@@ -791,6 +810,28 @@ impl AiService for AIProxyServer {
         &self,
         _request: tonic::Request<PurgeStores>,
     ) -> Result<tonic::Response<Del>, tonic::Status> {
+        let store_names: Vec<StoreName> = self
+            .store_handler
+            .list_stores()
+            .into_iter()
+            .map(|store| StoreName { value: store.name })
+            .collect();
+
+        if let Some(db_client) = &self.db_client {
+            let parent_id = tracer::span_to_trace_parent(tracing::Span::current());
+            for store_name in &store_names {
+                db_client
+                    .drop_store(
+                        DbDropStore {
+                            store: store_name.value.clone(),
+                            error_if_not_exists: false,
+                        },
+                        parent_id.clone(),
+                    )
+                    .await?;
+            }
+        }
+
         let deleted_count = self.store_handler.purge_stores();
         Ok(tonic::Response::new(Del {
             deleted_count: deleted_count as u64,

--- a/ahnlich/ai/src/tests/aiproxy_test.rs
+++ b/ahnlich/ai/src/tests/aiproxy_test.rs
@@ -5,7 +5,7 @@ use utils::server::AhnlichServerUtils;
 
 use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
-use std::{collections::HashMap, net::SocketAddr, sync::atomic::Ordering};
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf, sync::atomic::Ordering};
 
 use crate::{
     cli::{AIProxyConfig, server::SupportedModels},
@@ -29,6 +29,7 @@ use ahnlich_types::{
     },
     keyval::{AiStoreEntry, StoreInput, StoreName, StoreValue, store_input::Value},
     services::ai_service::ai_service_client::AiServiceClient,
+    services::db_service::db_service_client::DbServiceClient,
     shared::info::StoreUpsert,
 };
 use ahnlich_types::{
@@ -39,7 +40,6 @@ use ahnlich_types::{
     similarity::Similarity,
 };
 
-use std::path::PathBuf;
 use test_case::test_case;
 use tokio::time::Duration;
 use tonic::transport::Channel;
@@ -1241,6 +1241,91 @@ async fn test_ai_proxy_del_key_drop_store() {
 }
 
 #[tokio::test]
+async fn test_ai_proxy_drop_store_cascades_to_db() {
+    let server = Server::new(&CONFIG).await.expect("Failed to create server");
+    let db_address = server.local_addr().expect("Could not get local addr");
+
+    tokio::spawn(async move { server.start().await });
+
+    let mut config = AI_CONFIG.clone();
+    config.db_port = db_address.port();
+
+    let ai_server = AIProxyServer::new(config)
+        .await
+        .expect("Could not initialize ai proxy");
+    let ai_address = ai_server.local_addr().expect("Could not get local addr");
+    let _ = tokio::spawn(async move { ai_server.start().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let channel = Channel::from_shared(format!("http://{}", ai_address))
+        .expect("Failed to create AI channel")
+        .connect()
+        .await
+        .expect("Failed to connect AI channel");
+    let mut ai_client = AiServiceClient::new(channel);
+
+    let channel = Channel::from_shared(format!("http://{}", db_address))
+        .expect("Failed to create DB channel")
+        .connect()
+        .await
+        .expect("Failed to connect DB channel");
+    let mut db_client = DbServiceClient::new(channel);
+
+    let store_name = "Cascade Store".to_string();
+    let response = ai_client
+        .pipeline(tonic::Request::new(ai_pipeline::AiRequestPipeline {
+            queries: vec![
+                ai_pipeline::AiQuery {
+                    query: Some(Query::CreateStore(ai_query_types::CreateStore {
+                        store: store_name.clone(),
+                        query_model: AiModel::AllMiniLmL6V2.into(),
+                        index_model: AiModel::AllMiniLmL6V2.into(),
+                        predicates: vec![],
+                        non_linear_indices: vec![],
+                        error_if_exists: true,
+                        store_original: true,
+                    })),
+                },
+                ai_pipeline::AiQuery {
+                    query: Some(Query::DropStore(ai_query_types::DropStore {
+                        store: store_name.clone(),
+                        error_if_not_exists: true,
+                    })),
+                },
+                ai_pipeline::AiQuery {
+                    query: Some(Query::ListStores(ai_query_types::ListStores {})),
+                },
+            ],
+        }))
+        .await
+        .expect("Failed to execute AI pipeline")
+        .into_inner();
+
+    assert!(matches!(
+        &response.responses[0].response,
+        Some(ai_pipeline::ai_server_response::Response::Unit(_))
+    ));
+    assert!(matches!(
+        &response.responses[1].response,
+        Some(ai_pipeline::ai_server_response::Response::Del(d)) if d.deleted_count == 1
+    ));
+    if let Some(ai_pipeline::ai_server_response::Response::StoreList(store_list)) =
+        &response.responses[2].response
+    {
+        assert!(store_list.stores.is_empty());
+    } else {
+        panic!("Expected empty StoreList response");
+    }
+
+    let db_stores = db_client
+        .list_stores(tonic::Request::new(ahnlich_types::db::query::ListStores {}))
+        .await
+        .expect("Failed to list DB stores")
+        .into_inner();
+    assert!(db_stores.stores.is_empty());
+}
+
+#[tokio::test]
 async fn test_ai_proxy_del_pred() {
     let address = provision_test_servers().await;
     let address = format!("http://{}", address);
@@ -1600,6 +1685,102 @@ async fn test_ai_proxy_destroy_database() {
     } else {
         panic!("Expected empty StoreList response");
     }
+}
+
+#[tokio::test]
+async fn test_ai_proxy_purge_stores_cascades_to_db() {
+    let server = Server::new(&CONFIG).await.expect("Failed to create server");
+    let db_address = server.local_addr().expect("Could not get local addr");
+
+    tokio::spawn(async move { server.start().await });
+
+    let mut config = AI_CONFIG.clone();
+    config.db_port = db_address.port();
+
+    let ai_server = AIProxyServer::new(config)
+        .await
+        .expect("Could not initialize ai proxy");
+    let ai_address = ai_server.local_addr().expect("Could not get local addr");
+    let _ = tokio::spawn(async move { ai_server.start().await });
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let channel = Channel::from_shared(format!("http://{}", ai_address))
+        .expect("Failed to create AI channel")
+        .connect()
+        .await
+        .expect("Failed to connect AI channel");
+    let mut ai_client = AiServiceClient::new(channel);
+
+    let channel = Channel::from_shared(format!("http://{}", db_address))
+        .expect("Failed to create DB channel")
+        .connect()
+        .await
+        .expect("Failed to connect DB channel");
+    let mut db_client = DbServiceClient::new(channel);
+
+    let response = ai_client
+        .pipeline(tonic::Request::new(ai_pipeline::AiRequestPipeline {
+            queries: vec![
+                ai_pipeline::AiQuery {
+                    query: Some(Query::CreateStore(ai_query_types::CreateStore {
+                        store: "Cascade One".to_string(),
+                        query_model: AiModel::AllMiniLmL6V2.into(),
+                        index_model: AiModel::AllMiniLmL6V2.into(),
+                        predicates: vec![],
+                        non_linear_indices: vec![],
+                        error_if_exists: true,
+                        store_original: true,
+                    })),
+                },
+                ai_pipeline::AiQuery {
+                    query: Some(Query::CreateStore(ai_query_types::CreateStore {
+                        store: "Cascade Two".to_string(),
+                        query_model: AiModel::AllMiniLmL6V2.into(),
+                        index_model: AiModel::AllMiniLmL6V2.into(),
+                        predicates: vec![],
+                        non_linear_indices: vec![],
+                        error_if_exists: true,
+                        store_original: true,
+                    })),
+                },
+                ai_pipeline::AiQuery {
+                    query: Some(Query::PurgeStores(ai_query_types::PurgeStores {})),
+                },
+                ai_pipeline::AiQuery {
+                    query: Some(Query::ListStores(ai_query_types::ListStores {})),
+                },
+            ],
+        }))
+        .await
+        .expect("Failed to execute AI pipeline")
+        .into_inner();
+
+    assert!(matches!(
+        &response.responses[0].response,
+        Some(ai_pipeline::ai_server_response::Response::Unit(_))
+    ));
+    assert!(matches!(
+        &response.responses[1].response,
+        Some(ai_pipeline::ai_server_response::Response::Unit(_))
+    ));
+    assert!(matches!(
+        &response.responses[2].response,
+        Some(ai_pipeline::ai_server_response::Response::Del(d)) if d.deleted_count == 2
+    ));
+    if let Some(ai_pipeline::ai_server_response::Response::StoreList(store_list)) =
+        &response.responses[3].response
+    {
+        assert!(store_list.stores.is_empty());
+    } else {
+        panic!("Expected empty StoreList response");
+    }
+
+    let db_stores = db_client
+        .list_stores(tonic::Request::new(ahnlich_types::db::query::ListStores {}))
+        .await
+        .expect("Failed to list DB stores")
+        .into_inner();
+    assert!(db_stores.stores.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #326