### PR TITLE
feat(charts): Helm charts for ahnlich-db, ahnlich-ai, and umbrella

### DIFF
--- a/.github/workflows/helm-charts.yml
+++ b/.github/workflows/helm-charts.yml
@@ -1,0 +1,151 @@
+name: Helm Charts
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+      - '.github/workflows/helm-charts.yml'
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint and template
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Build umbrella dependencies
+        run: helm dependency build charts/ahnlich
+
+      - name: Lint all charts
+        run: helm lint charts/ahnlich-db charts/ahnlich-ai charts/ahnlich
+
+      - name: Render standalone
+        run: |
+          helm template ahnlich charts/ahnlich-db >/dev/null
+          helm template ahnlich charts/ahnlich-ai --set db.host=test-db >/dev/null
+          helm template ahnlich charts/ahnlich >/dev/null
+
+      - name: Render cluster mode
+        run: |
+          helm template ahnlich charts/ahnlich-db --set cluster.enabled=true >/dev/null
+          helm template ahnlich charts/ahnlich-ai --set db.host=test-db --set cluster.enabled=true >/dev/null
+          helm template ahnlich charts/ahnlich \
+            --set ahnlich-db.cluster.enabled=true \
+            --set ahnlich-ai.cluster.enabled=true >/dev/null
+
+      - name: Validate release-name guard
+        run: |
+          # Should fail at template time when release name != "ahnlich" without overrides.
+          if helm template foo charts/ahnlich >/dev/null 2>&1; then
+            echo "release-name guard did not fire" >&2
+            exit 1
+          fi
+          # And should succeed with the documented override.
+          helm template foo charts/ahnlich --set ahnlich-ai.db.host=foo-ahnlich-db >/dev/null
+
+  smoke-standalone:
+    name: Standalone smoke install
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          wait: 120s
+
+      - name: Build umbrella dependencies
+        run: helm dependency build charts/ahnlich
+
+      - name: Install ahnlich
+        # Override the model set to just all-minilm-l6-v2 to keep first-run model
+        # download fast (CI runners have limited disk + bandwidth).
+        run: |
+          helm install ahnlich charts/ahnlich \
+            --set 'ahnlich-ai.models.supported={all-minilm-l6-v2}' \
+            --wait --timeout 10m
+
+      - name: PING DB
+        run: |
+          kubectl exec sts/ahnlich-ahnlich-db -- sh -c "echo PING | ahnlich-cli ahnlich --agent db --host 127.0.0.1 --port 1369 --no-interactive"
+
+      - name: PING AI
+        run: |
+          kubectl exec sts/ahnlich-ahnlich-ai -- sh -c "echo PING | ahnlich-cli ahnlich --agent ai --host 127.0.0.1 --port 1370 --no-interactive"
+
+      - name: CREATESTORE via AI (validates AI to DB proxy)
+        run: |
+          kubectl exec sts/ahnlich-ahnlich-ai -- sh -c "echo 'CREATESTORE smoke QUERYMODEL all-minilm-l6-v2 INDEXMODEL all-minilm-l6-v2' | ahnlich-cli ahnlich --agent ai --host 127.0.0.1 --port 1370 --no-interactive"
+
+      - name: LISTSTORES via DB (confirms store created end-to-end)
+        run: |
+          kubectl exec sts/ahnlich-ahnlich-db -- sh -c "echo LISTSTORES | ahnlich-cli ahnlich --agent db --host 127.0.0.1 --port 1369 --no-interactive" | tee /tmp/stores
+          grep -q '"smoke"' /tmp/stores
+
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          kubectl get pods,svc,pvc,events --all-namespaces
+          kubectl logs sts/ahnlich-ahnlich-db --tail 200 || true
+          kubectl logs sts/ahnlich-ahnlich-ai --tail 200 || true
+          kubectl logs sts/ahnlich-ahnlich-ai -c wait-for-db --tail 100 || true
+
+  smoke-cluster:
+    name: Cluster (Raft) smoke install
+    runs-on: ubuntu-latest
+    needs: lint
+    # The ahnlich binary does not yet accept the --cluster-* CLI flags. Flip
+    # this gate to `true` once the Raft CLI surface lands so chart-side cluster
+    # mode is exercised on every PR and release.
+    if: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          wait: 180s
+
+      - name: Build umbrella dependencies
+        run: helm dependency build charts/ahnlich
+
+      - name: Install ahnlich (cluster mode)
+        run: |
+          helm install ahnlich charts/ahnlich \
+            --set ahnlich-db.cluster.enabled=true \
+            --set ahnlich-ai.cluster.enabled=true \
+            --set 'ahnlich-ai.models.supported={all-minilm-l6-v2}' \
+            --wait --timeout 15m
+
+      - name: PING DB on follower pod
+        run: |
+          kubectl exec ahnlich-ahnlich-db-1 -- sh -c "echo PING | ahnlich-cli ahnlich --agent db --host 127.0.0.1 --port 1369 --no-interactive"
+
+      - name: PING AI on follower pod
+        run: |
+          kubectl exec ahnlich-ahnlich-ai-1 -- sh -c "echo PING | ahnlich-cli ahnlich --agent ai --host 127.0.0.1 --port 1370 --no-interactive"
+
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          kubectl get pods,svc,pvc,events --all-namespaces
+          for p in ahnlich-ahnlich-db-0 ahnlich-ahnlich-db-1 ahnlich-ahnlich-db-2; do
+            kubectl logs "$p" --tail 200 || true
+          done
+          for p in ahnlich-ahnlich-ai-0 ahnlich-ahnlich-ai-1 ahnlich-ahnlich-ai-2; do
+            kubectl logs "$p" --tail 200 || true
+            kubectl logs "$p" -c wait-for-db --tail 100 || true
+          done

--- a/.github/workflows/helm-charts.yml
+++ b/.github/workflows/helm-charts.yml
@@ -13,6 +13,25 @@ permissions:
   contents: read
 
 jobs:
+  docs:
+    name: helm-docs up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Regenerate chart docs
+        run: |
+          docker run --rm -v "$(pwd):/helm-docs" -u "$(id -u)" \
+            jnorwood/helm-docs:v1.14.2 \
+            helm-docs --chart-search-root=charts
+
+      - name: Fail if docs are stale
+        run: |
+          if ! git diff --exit-code -- 'charts/*/README.md'; then
+            echo "::error::Chart README.md is out of date. Run 'helm-docs --chart-search-root=charts' and commit the result." >&2
+            exit 1
+          fi
+
   lint:
     name: Lint and template
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ node_modules/
 .DS_Store
 docs/superpowers/
 .worktrees/
+
+# Helm vendored sub-chart packages (rebuilt from local sources via `helm dependency build`).
+# Chart.lock IS committed for reproducible builds.
+charts/*/charts/*.tgz

--- a/charts/ahnlich-ai/.helmignore
+++ b/charts/ahnlich-ai/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ahnlich-ai/Chart.yaml
+++ b/charts/ahnlich-ai/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: ahnlich-ai
+description: Helm chart for ahnlich-ai, the embedding / AI proxy in front of ahnlich-db.
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/deven96/ahnlich
+sources:
+  - https://github.com/deven96/ahnlich
+keywords:
+  - embeddings
+  - ai
+  - vector-database
+  - ahnlich

--- a/charts/ahnlich-ai/README.md
+++ b/charts/ahnlich-ai/README.md
@@ -1,0 +1,181 @@
+# ahnlich-ai
+
+Helm chart for `ahnlich-ai`, the embedding / AI proxy that sits in front of `ahnlich-db`.
+
+Architecturally, `ahnlich-ai` accepts raw inputs (text / image / audio), turns them into embeddings via ONNX models, and forwards everything to a backing `ahnlich-db` cluster over gRPC. This chart deploys the AI process; it does **not** deploy `ahnlich-db` — point `db.host` at an existing DB.
+
+The chart supports two deployment modes:
+
+- **Standalone** (default): single replica with periodic JSON-snapshot persistence of AI-local store metadata.
+- **Cluster (Raft)**: N replicas forming a Raft cluster for AI-local state. Activate with `--set cluster.enabled=true`.
+
+## Prerequisites
+
+- Kubernetes 1.20+ (for `appProtocol: grpc`).
+- A default `StorageClass` (the chart falls back to it unless overridden).
+- A reachable `ahnlich-db` deployment. Point `db.host` at its Service DNS name.
+- Optional, for external L7 access: an Ingress Controller or Gateway API implementation.
+
+## Quick start
+
+```bash
+# Standalone AI talking to an existing DB
+helm install my-ai charts/ahnlich-ai \
+  --set db.host=my-ahnlich-ahnlich-db
+
+# With tracing
+helm install my-ai charts/ahnlich-ai \
+  --set db.host=my-ahnlich-ahnlich-db \
+  --set tracing.enabled=true \
+  --set tracing.otelEndpoint=http://jaeger-collector:4317
+
+# Exposed externally
+helm install my-ai charts/ahnlich-ai \
+  --set db.host=my-ahnlich-ahnlich-db \
+  --set service.type=LoadBalancer
+```
+
+## Values
+
+### Image
+
+| Key | Default | Description |
+|---|---|---|
+| `image.repository` | `ghcr.io/deven96/ahnlich-ai` | Image repository. |
+| `image.tag` | `latest` | Image tag. |
+| `image.pullPolicy` | `IfNotPresent` | Standard k8s pull policy. |
+
+### Backing DB
+
+| Key | Default | Description |
+|---|---|---|
+| `db.host` | `""` | **Required.** DNS name of the backing ahnlich-db Service. |
+| `db.port` | `1369` | DB port. |
+
+The AI pod connects to the DB over gRPC. For a co-located DB install with default release name `my-ahnlich`, the value is typically `my-ahnlich-ahnlich-db` (same namespace) or `my-ahnlich-ahnlich-db.<db-namespace>.svc.cluster.local` (cross-namespace).
+
+### Models
+
+| Key | Default | Description |
+|---|---|---|
+| `models.supported` | `[all-minilm-l6-v2, resnet-50]` | List of model names; joined into `--supported-models`. |
+| `models.cache.size` | `20Gi` | PVC size for the model cache. |
+| `models.cache.storageClass` | `""` | StorageClass; empty = cluster default. |
+| `models.cache.mountPath` | `/root/.ahnlich/models` | In-container model cache path. |
+
+Each replica gets its own model-cache PVC. Models are downloaded on first use and reused across restarts.
+
+### Service
+
+| Key | Default | Description |
+|---|---|---|
+| `service.type` | `ClusterIP` | One of `ClusterIP`, `LoadBalancer`, `NodePort`. |
+| `service.port` | `1370` | Public client-facing gRPC port. |
+
+`appProtocol: grpc` is set on the port for Ingress/Gateway controller auto-discovery.
+
+### Standalone persistence
+
+| Key | Default | Description |
+|---|---|---|
+| `persistence.enabled` | `true` | Mount a PVC at `mountPath` and pass `--enable-persistence`. |
+| `persistence.size` | `5Gi` | AI-local metadata is small; smaller default than DB. |
+| `persistence.storageClass` | `""` | StorageClass; empty = cluster default. |
+| `persistence.mountPath` | `/root/.ahnlich/data` | In-container mount point. |
+| `persistence.fileName` | `ai.dat` | Snapshot file name. |
+| `persistence.intervalMs` | `30000` | `--persistence-interval` value in ms. |
+
+Automatically suppressed when `cluster.enabled=true` (Raft snapshots and log replication replace standalone persistence).
+
+### Cluster (Raft) mode
+
+| Key | Default | Description |
+|---|---|---|
+| `cluster.enabled` | `false` | Run N replicas as an AI-local Raft cluster. |
+| `cluster.replicas` | `3` | StatefulSet replica count. |
+| `cluster.port` | `1371` | `--cluster-addr` port for Raft RPCs. |
+| `cluster.storage` | `rocksdb` | `rocksdb` (production) or `memory` (testing only). |
+| `cluster.dataDir` | `/root/.ahnlich/raft` | `--cluster-data-dir`. |
+| `cluster.snapshotLogs` | `1000` | Count-based snapshot trigger. |
+| `cluster.snapshotIntervalMs` | `300000` | Time-based snapshot trigger. |
+| `cluster.persistence.size` | `10Gi` | PVC size for the Raft data dir. |
+| `cluster.persistence.storageClass` | `""` | StorageClass; empty = cluster default. |
+| `cluster.podDisruptionBudget.enabled` | `true` | Protect quorum during voluntary disruptions. |
+| `cluster.podDisruptionBudget.minAvailable` | `2` | Minimum pods that must stay up. |
+
+The AI cluster only replicates store metadata (CreateStore, DropStore, PurgeStores). All other mutations are proxied to the DB cluster via `db.host` and replicated by the DB's own Raft cluster.
+
+### Tracing
+
+| Key | Default | Description |
+|---|---|---|
+| `tracing.enabled` | `false` | Pass `--enable-tracing --otel-endpoint=...`. |
+| `tracing.otelEndpoint` | `""` | OTLP gRPC endpoint. |
+
+The chart does not deploy a tracing backend.
+
+### Ingress and Gateway
+
+Identical surface to `ahnlich-db`:
+
+- `ingress.*` produces an `Ingress` resource (controller required in-cluster).
+- `gateway.*` produces a `GRPCRoute` attached to an existing Gateway.
+- Both enabled simultaneously is a misconfiguration; the chart fails the install.
+
+See the `ahnlich-db` README for the full key reference.
+
+### Logging
+
+| Key | Default | Description |
+|---|---|---|
+| `logLevel` | `""` | Sets `--log-level` on the binary. Empty = the binary's default (`info,hf_hub=warn`). Example values: `debug`, `trace`, `info,ahnlich_ai_proxy=debug`. |
+
+`ahnlich-ai` reads its log filter from `--log-level`, **not** from `RUST_LOG`. Setting `RUST_LOG` via `env` has no effect.
+
+### Environment variables
+
+| Key | Default | Description |
+|---|---|---|
+| `env` | `[]` | List of `EnvVar` entries (`name/value` or `valueFrom`). |
+| `envFrom` | `[]` | List of `EnvFromSource` entries (`configMapRef` or `secretRef`). |
+
+For process env not exposed as a flag (`RUST_BACKTRACE=1`, `ORT_DYLIB_PATH` for a custom ONNX Runtime build, etc.). Both keys take the standard k8s shape. For log verbosity use `logLevel` above instead.
+
+### Pod scheduling and resources
+
+| Key | Default | Description |
+|---|---|---|
+| `resources` | `{}` | Container `resources` block. AI is heavier than DB; set requests/limits per workload. |
+| `nodeSelector` | `{}` | Schedule on nodes matching these labels. |
+| `tolerations` | `[]` | Tolerate node taints. |
+| `affinity` | `{}` | Pod / node affinity. |
+| `podAnnotations` | `{}` | Free-form pod annotations. |
+
+GPU acceleration: add `nvidia.com/gpu` to `resources.limits` and a matching `nodeSelector` (typically `nvidia.com/gpu.present: "true"` or a vendor-specific label). The image ships with the CUDA ONNX Runtime.
+
+### Probes
+
+`probes.readiness.*` and `probes.liveness.*` accept the standard k8s timing fields. Both probes run `ahnlich-cli PING` (with `--agent ai`) against the local pod. Liveness `initialDelaySeconds` defaults to 60s to cover first-time model download on container start.
+
+## External access patterns
+
+Same three options as `ahnlich-db`:
+
+1. `service.type=LoadBalancer` — L4, one external IP per Service.
+2. `ingress.enabled=true` — shared edge router, TLS, hostname routing.
+3. `gateway.enabled=true` — Gateway API, gRPC-aware via `GRPCRoute` with optional per-method matching.
+
+For in-cluster clients (e.g., your own app calling the AI), leave `service.type=ClusterIP` and reach the AI at `<release>-ahnlich-ai.<namespace>.svc.cluster.local:<port>`.
+
+## Upgrading
+
+`helm upgrade my-ai charts/ahnlich-ai` rolls pods one at a time. PVCs (models cache and persistence data) survive the upgrade.
+
+In cluster mode, the PodDisruptionBudget at `minAvailable: 2` keeps quorum intact through rolling upgrades.
+
+## Uninstalling
+
+```bash
+helm uninstall my-ai
+kubectl delete pvc -l app.kubernetes.io/instance=my-ai      # only if you also want to drop the cached models / data
+```

--- a/charts/ahnlich-ai/README.md
+++ b/charts/ahnlich-ai/README.md
@@ -37,149 +37,88 @@ helm install my-ai charts/ahnlich-ai \
 
 ## Values
 
-### Image
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling. |
+| cluster.dataDir | string | `"/root/.ahnlich/raft"` | `--cluster-data-dir` (RocksDB log + snapshots). |
+| cluster.enabled | bool | `false` | Run N replicas as an AI-local Raft cluster instead of a single standalone node. |
+| cluster.persistence.size | string | `"10Gi"` | PVC size for the Raft data dir (AI replicates only metadata, so logs grow slower than DB's). |
+| cluster.persistence.storageClass | string | `""` | StorageClass for the Raft data dir. Empty uses the cluster default. |
+| cluster.podDisruptionBudget.enabled | bool | `true` | Create a PodDisruptionBudget in cluster mode. |
+| cluster.podDisruptionBudget.maxUnavailable | int | `1` | Pods that may be evicted at once; scales with replicas. |
+| cluster.port | int | `1371` | `--cluster-addr` port for Raft RPCs. |
+| cluster.replicas | int | `3` | StatefulSet replica count in cluster mode. |
+| cluster.snapshotIntervalMs | int | `300000` | `--cluster-snapshot-interval` time-based snapshot trigger (ms). |
+| cluster.snapshotLogs | int | `1000` | `--cluster-snapshot-logs` count-based snapshot trigger. |
+| cluster.storage | string | `"rocksdb"` | Raft storage backend: `rocksdb` (production) or `memory` (testing only, no durability). |
+| db.host | string | `""` | DNS name of the backing ahnlich-db Service (required), e.g. `my-ahnlich-ahnlich-db`. |
+| db.port | int | `1369` | DB port. |
+| db.waitForReady.enabled | bool | `true` | Block AI startup with an initContainer until the DB Service port opens (mirrors docker-compose `depends_on: service_healthy`). |
+| db.waitForReady.image | string | `"busybox:1.36.1"` | Image used for the wait probe (needs `nc`). |
+| db.waitForReady.intervalSeconds | int | `2` | Poll interval between port checks (s). |
+| db.waitForReady.timeoutSeconds | int | `300` | How long to keep retrying before failing the pod (s). |
+| env | list | `[]` | Extra environment variables (name/value or valueFrom). Use for `RUST_BACKTRACE`, `ORT_DYLIB_PATH`, etc. |
+| envFrom | list | `[]` | Bulk-import env from ConfigMaps or Secrets. |
+| gateway.enabled | bool | `false` | Create a GRPCRoute attached to an existing Gateway (mutually exclusive with `ingress`). |
+| gateway.hostnames | list | `[]` | Hostnames the route claims, e.g. `["ai.example.com"]`. |
+| gateway.parentRefs | list | `[{"name":"","namespace":"","sectionName":""}]` | Existing Gateway references; `name` is required when `gateway.enabled`. |
+| image.pullPolicy | string | `""` | Pull policy. Empty selects `Always` for the `latest` tag, `IfNotPresent` otherwise. |
+| image.repository | string | `"ghcr.io/deven96/ahnlich-ai"` | Image repository. |
+| image.tag | string | `"latest"` | Image tag. |
+| ingress.annotations | object | `{}` | Controller-specific annotations (e.g. nginx-ingress `backend-protocol: GRPC`). |
+| ingress.className | string | `""` | IngressClass name. Empty uses the cluster default. |
+| ingress.enabled | bool | `false` | Create an Ingress resource (requires an Ingress Controller in the cluster). |
+| ingress.host | string | `""` | Hostname, e.g. `ai.example.com`. Required when `ingress.tls.enabled`. |
+| ingress.path | string | `"/"` | Path prefix. |
+| ingress.pathType | string | `"Prefix"` | Path type: `Prefix`, `Exact`, or `ImplementationSpecific`. |
+| ingress.tls.enabled | bool | `false` | Add a TLS block to the Ingress. |
+| ingress.tls.secretName | string | `""` | Name of an existing TLS Secret in this namespace. |
+| logLevel | string | `""` | `--log-level` (env_logger / tracing-subscriber syntax). Empty uses the binary default (`info,hf_hub=warn`). |
+| models.cache.mountPath | string | `"/root/.ahnlich/models"` | In-container model cache path. |
+| models.cache.size | string | `"20Gi"` | PVC size for the model cache. |
+| models.cache.storageClass | string | `""` | StorageClass for the model cache. Empty uses the cluster default. |
+| models.supported | list | `["all-minilm-l6-v2","resnet-50"]` | Model names served by this instance; comma-joined into `--supported-models`. |
+| nodeSelector | object | `{}` | Node selector for pod scheduling. |
+| persistence.enabled | bool | `true` | Mount a PVC and pass `--enable-persistence` (standalone mode only). |
+| persistence.fileName | string | `"ai.dat"` | Snapshot file name. |
+| persistence.intervalMs | int | `30000` | `--persistence-interval` value (ms). |
+| persistence.mountPath | string | `"/root/.ahnlich/data"` | In-container mount point for the snapshot. |
+| persistence.size | string | `"5Gi"` | PVC size for the AI-local metadata snapshot (small). |
+| persistence.storageClass | string | `""` | StorageClass for the snapshot PVC. Empty uses the cluster default. |
+| podAnnotations | object | `{}` | Annotations added to the pod template. |
+| podLabels | object | `{}` | Extra labels added to the pod template (not the selector). |
+| probes.liveness.failureThreshold | int | `3` | Liveness probe failure threshold. |
+| probes.liveness.initialDelaySeconds | int | `60` | Liveness probe initial delay (s); higher default to cover first-run model download. |
+| probes.liveness.periodSeconds | int | `30` | Liveness probe period (s). |
+| probes.liveness.timeoutSeconds | int | `5` | Liveness probe timeout (s). |
+| probes.readiness.failureThreshold | int | `3` | Readiness probe failure threshold. |
+| probes.readiness.initialDelaySeconds | int | `10` | Readiness probe initial delay (s). |
+| probes.readiness.periodSeconds | int | `10` | Readiness probe period (s). |
+| probes.readiness.timeoutSeconds | int | `5` | Readiness probe timeout (s). |
+| resources | object | `{}` | Container resource requests/limits. AI is heavier than DB; for GPU add `nvidia.com/gpu` to limits plus a matching nodeSelector. |
+| service.port | int | `1370` | `--port`, the public client-facing gRPC port. |
+| service.type | string | `"ClusterIP"` | Service type: `ClusterIP`, `LoadBalancer`, or `NodePort`. |
+| tolerations | list | `[]` | Tolerations for pod scheduling. |
+| tracing.enabled | bool | `false` | Pass `--enable-tracing` and `--otel-endpoint`. |
+| tracing.otelEndpoint | string | `""` | OTLP gRPC endpoint, e.g. `http://jaeger-collector:4317`. |
 
-| Key | Default | Description |
-|---|---|---|
-| `image.repository` | `ghcr.io/deven96/ahnlich-ai` | Image repository. |
-| `image.tag` | `latest` | Image tag. |
-| `image.pullPolicy` | `IfNotPresent` | Standard k8s pull policy. |
+## Notes
 
-### Backing DB
+- **Backing DB.** The AI pod connects to the DB over gRPC at `db.host:db.port`. For a co-located DB install named `my-ahnlich`, that's typically `my-ahnlich-ahnlich-db` (same namespace) or `my-ahnlich-ahnlich-db.<db-namespace>.svc.cluster.local` (cross-namespace). The `db.waitForReady` initContainer blocks startup until that port is reachable; disable it only if the DB lives somewhere k8s can't reach via a Service.
+- **Model cache.** Each replica gets its own model-cache PVC. Models are downloaded on first use and reused across restarts. The liveness probe's 60s initial delay covers first-run download.
+- **AI cluster scope.** In cluster mode the AI Raft cluster only replicates store metadata (CreateStore, DropStore, PurgeStores). All other mutations are proxied to the DB cluster via `db.host` and replicated by the DB's own Raft cluster.
+- **Logging.** `ahnlich-ai` reads its log filter from `--log-level`, **not** `RUST_LOG`. Use `logLevel` for verbosity; `env`/`envFrom` for other process env.
+- **GPU.** The image ships the CUDA ONNX Runtime. Add `nvidia.com/gpu` to `resources.limits` and a matching `nodeSelector` to schedule on GPU nodes.
 
-| Key | Default | Description |
-|---|---|---|
-| `db.host` | `""` | **Required.** DNS name of the backing ahnlich-db Service. |
-| `db.port` | `1369` | DB port. |
-| `db.waitForReady.enabled` | `true` | Block AI startup with an initContainer until the DB Service port opens. Mirrors docker-compose `depends_on: service_healthy`. |
-| `db.waitForReady.image` | `busybox:1.36` | Image used for the wait probe (just needs `nc`). |
-| `db.waitForReady.timeoutSeconds` | `300` | How long to keep retrying before failing the pod. |
-| `db.waitForReady.intervalSeconds` | `2` | Poll interval between port checks. |
-
-The AI pod connects to the DB over gRPC. For a co-located DB install with default release name `my-ahnlich`, the value is typically `my-ahnlich-ahnlich-db` (same namespace) or `my-ahnlich-ahnlich-db.<db-namespace>.svc.cluster.local` (cross-namespace). Disable `db.waitForReady.enabled` if the DB lives somewhere k8s can't reach via a Service (external host, etc.) — though in that case the AI will still crash-restart until the connection succeeds, just without the initContainer's friendlier delay.
-
-### Models
-
-| Key | Default | Description |
-|---|---|---|
-| `models.supported` | `[all-minilm-l6-v2, resnet-50]` | List of model names; joined into `--supported-models`. |
-| `models.cache.size` | `20Gi` | PVC size for the model cache. |
-| `models.cache.storageClass` | `""` | StorageClass; empty = cluster default. |
-| `models.cache.mountPath` | `/root/.ahnlich/models` | In-container model cache path. |
-
-Each replica gets its own model-cache PVC. Models are downloaded on first use and reused across restarts.
-
-### Service
-
-| Key | Default | Description |
-|---|---|---|
-| `service.type` | `ClusterIP` | One of `ClusterIP`, `LoadBalancer`, `NodePort`. |
-| `service.port` | `1370` | Public client-facing gRPC port. |
-
-`appProtocol: grpc` is set on the port for Ingress/Gateway controller auto-discovery.
-
-### Standalone persistence
-
-| Key | Default | Description |
-|---|---|---|
-| `persistence.enabled` | `true` | Mount a PVC at `mountPath` and pass `--enable-persistence`. |
-| `persistence.size` | `5Gi` | AI-local metadata is small; smaller default than DB. |
-| `persistence.storageClass` | `""` | StorageClass; empty = cluster default. |
-| `persistence.mountPath` | `/root/.ahnlich/data` | In-container mount point. |
-| `persistence.fileName` | `ai.dat` | Snapshot file name. |
-| `persistence.intervalMs` | `30000` | `--persistence-interval` value in ms. |
-
-Automatically suppressed when `cluster.enabled=true` (Raft snapshots and log replication replace standalone persistence).
-
-### Cluster (Raft) mode
-
-| Key | Default | Description |
-|---|---|---|
-| `cluster.enabled` | `false` | Run N replicas as an AI-local Raft cluster. |
-| `cluster.replicas` | `3` | StatefulSet replica count. |
-| `cluster.port` | `1371` | `--cluster-addr` port for Raft RPCs. |
-| `cluster.storage` | `rocksdb` | `rocksdb` (production) or `memory` (testing only). |
-| `cluster.dataDir` | `/root/.ahnlich/raft` | `--cluster-data-dir`. |
-| `cluster.snapshotLogs` | `1000` | Count-based snapshot trigger. |
-| `cluster.snapshotIntervalMs` | `300000` | Time-based snapshot trigger. |
-| `cluster.persistence.size` | `10Gi` | PVC size for the Raft data dir. |
-| `cluster.persistence.storageClass` | `""` | StorageClass; empty = cluster default. |
-| `cluster.podDisruptionBudget.enabled` | `true` | Protect quorum during voluntary disruptions. |
-| `cluster.podDisruptionBudget.minAvailable` | `2` | Minimum pods that must stay up. |
-
-The AI cluster only replicates store metadata (CreateStore, DropStore, PurgeStores). All other mutations are proxied to the DB cluster via `db.host` and replicated by the DB's own Raft cluster.
-
-### Tracing
-
-| Key | Default | Description |
-|---|---|---|
-| `tracing.enabled` | `false` | Pass `--enable-tracing --otel-endpoint=...`. |
-| `tracing.otelEndpoint` | `""` | OTLP gRPC endpoint. |
-
-The chart does not deploy a tracing backend.
-
-### Ingress and Gateway
-
-Identical surface to `ahnlich-db`:
-
-- `ingress.*` produces an `Ingress` resource (controller required in-cluster).
-- `gateway.*` produces a `GRPCRoute` attached to an existing Gateway.
-- Both enabled simultaneously is a misconfiguration; the chart fails the install.
-
-See the `ahnlich-db` README for the full key reference.
-
-### Logging
-
-| Key | Default | Description |
-|---|---|---|
-| `logLevel` | `""` | Sets `--log-level` on the binary. Empty = the binary's default (`info,hf_hub=warn`). Example values: `debug`, `trace`, `info,ahnlich_ai_proxy=debug`. |
-
-`ahnlich-ai` reads its log filter from `--log-level`, **not** from `RUST_LOG`. Setting `RUST_LOG` via `env` has no effect.
-
-### Environment variables
-
-| Key | Default | Description |
-|---|---|---|
-| `env` | `[]` | List of `EnvVar` entries (`name/value` or `valueFrom`). |
-| `envFrom` | `[]` | List of `EnvFromSource` entries (`configMapRef` or `secretRef`). |
-
-For process env not exposed as a flag (`RUST_BACKTRACE=1`, `ORT_DYLIB_PATH` for a custom ONNX Runtime build, etc.). Both keys take the standard k8s shape. For log verbosity use `logLevel` above instead.
-
-### Pod scheduling and resources
-
-| Key | Default | Description |
-|---|---|---|
-| `resources` | `{}` | Container `resources` block. AI is heavier than DB; set requests/limits per workload. |
-| `nodeSelector` | `{}` | Schedule on nodes matching these labels. |
-| `tolerations` | `[]` | Tolerate node taints. |
-| `affinity` | `{}` | Pod / node affinity. |
-| `podAnnotations` | `{}` | Free-form pod annotations. |
-
-GPU acceleration: add `nvidia.com/gpu` to `resources.limits` and a matching `nodeSelector` (typically `nvidia.com/gpu.present: "true"` or a vendor-specific label). The image ships with the CUDA ONNX Runtime.
-
-### Probes
-
-`probes.readiness.*` and `probes.liveness.*` accept the standard k8s timing fields. Both probes run `ahnlich-cli PING` (with `--agent ai`) against the local pod. Liveness `initialDelaySeconds` defaults to 60s to cover first-time model download on container start.
-
-## External access patterns
-
-Same three options as `ahnlich-db`:
-
-1. `service.type=LoadBalancer` — L4, one external IP per Service.
-2. `ingress.enabled=true` — shared edge router, TLS, hostname routing.
-3. `gateway.enabled=true` — Gateway API, gRPC-aware via `GRPCRoute` with optional per-method matching.
-
-For in-cluster clients (e.g., your own app calling the AI), leave `service.type=ClusterIP` and reach the AI at `<release>-ahnlich-ai.<namespace>.svc.cluster.local:<port>`.
+The Service port advertises `appProtocol: grpc` for Ingress/Gateway controller auto-discovery. Enabling `ingress.enabled` and `gateway.enabled` together is a misconfiguration; the chart fails the install with an explicit error. See the `ahnlich-db` README for the controller-specific gRPC notes and external-access patterns — the surface is identical here.
 
 ## Upgrading
 
-`helm upgrade my-ai charts/ahnlich-ai` rolls pods one at a time. PVCs (models cache and persistence data) survive the upgrade.
-
-In cluster mode, the PodDisruptionBudget at `minAvailable: 2` keeps quorum intact through rolling upgrades.
+`helm upgrade my-ai charts/ahnlich-ai` rolls pods one at a time. PVCs (model cache and persistence data) survive the upgrade. In cluster mode, the PodDisruptionBudget (`maxUnavailable: 1`) keeps quorum intact.
 
 ## Uninstalling
 
 ```bash
 helm uninstall my-ai
-kubectl delete pvc -l app.kubernetes.io/instance=my-ai      # only if you also want to drop the cached models / data
+kubectl delete pvc -l app.kubernetes.io/instance=my-ai   # only if you also want to drop cached models / data
 ```

--- a/charts/ahnlich-ai/README.md
+++ b/charts/ahnlich-ai/README.md
@@ -51,8 +51,12 @@ helm install my-ai charts/ahnlich-ai \
 |---|---|---|
 | `db.host` | `""` | **Required.** DNS name of the backing ahnlich-db Service. |
 | `db.port` | `1369` | DB port. |
+| `db.waitForReady.enabled` | `true` | Block AI startup with an initContainer until the DB Service port opens. Mirrors docker-compose `depends_on: service_healthy`. |
+| `db.waitForReady.image` | `busybox:1.36` | Image used for the wait probe (just needs `nc`). |
+| `db.waitForReady.timeoutSeconds` | `300` | How long to keep retrying before failing the pod. |
+| `db.waitForReady.intervalSeconds` | `2` | Poll interval between port checks. |
 
-The AI pod connects to the DB over gRPC. For a co-located DB install with default release name `my-ahnlich`, the value is typically `my-ahnlich-ahnlich-db` (same namespace) or `my-ahnlich-ahnlich-db.<db-namespace>.svc.cluster.local` (cross-namespace).
+The AI pod connects to the DB over gRPC. For a co-located DB install with default release name `my-ahnlich`, the value is typically `my-ahnlich-ahnlich-db` (same namespace) or `my-ahnlich-ahnlich-db.<db-namespace>.svc.cluster.local` (cross-namespace). Disable `db.waitForReady.enabled` if the DB lives somewhere k8s can't reach via a Service (external host, etc.) — though in that case the AI will still crash-restart until the connection succeeds, just without the initContainer's friendlier delay.
 
 ### Models
 

--- a/charts/ahnlich-ai/README.md.gotmpl
+++ b/charts/ahnlich-ai/README.md.gotmpl
@@ -1,0 +1,59 @@
+# ahnlich-ai
+
+Helm chart for `ahnlich-ai`, the embedding / AI proxy that sits in front of `ahnlich-db`.
+
+Architecturally, `ahnlich-ai` accepts raw inputs (text / image / audio), turns them into embeddings via ONNX models, and forwards everything to a backing `ahnlich-db` cluster over gRPC. This chart deploys the AI process; it does **not** deploy `ahnlich-db` — point `db.host` at an existing DB.
+
+The chart supports two deployment modes:
+
+- **Standalone** (default): single replica with periodic JSON-snapshot persistence of AI-local store metadata.
+- **Cluster (Raft)**: N replicas forming a Raft cluster for AI-local state. Activate with `--set cluster.enabled=true`.
+
+## Prerequisites
+
+- Kubernetes 1.20+ (for `appProtocol: grpc`).
+- A default `StorageClass` (the chart falls back to it unless overridden).
+- A reachable `ahnlich-db` deployment. Point `db.host` at its Service DNS name.
+- Optional, for external L7 access: an Ingress Controller or Gateway API implementation.
+
+## Quick start
+
+```bash
+# Standalone AI talking to an existing DB
+helm install my-ai charts/ahnlich-ai \
+  --set db.host=my-ahnlich-ahnlich-db
+
+# With tracing
+helm install my-ai charts/ahnlich-ai \
+  --set db.host=my-ahnlich-ahnlich-db \
+  --set tracing.enabled=true \
+  --set tracing.otelEndpoint=http://jaeger-collector:4317
+
+# Exposed externally
+helm install my-ai charts/ahnlich-ai \
+  --set db.host=my-ahnlich-ahnlich-db \
+  --set service.type=LoadBalancer
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Notes
+
+- **Backing DB.** The AI pod connects to the DB over gRPC at `db.host:db.port`. For a co-located DB install named `my-ahnlich`, that's typically `my-ahnlich-ahnlich-db` (same namespace) or `my-ahnlich-ahnlich-db.<db-namespace>.svc.cluster.local` (cross-namespace). The `db.waitForReady` initContainer blocks startup until that port is reachable; disable it only if the DB lives somewhere k8s can't reach via a Service.
+- **Model cache.** Each replica gets its own model-cache PVC. Models are downloaded on first use and reused across restarts. The liveness probe's 60s initial delay covers first-run download.
+- **AI cluster scope.** In cluster mode the AI Raft cluster only replicates store metadata (CreateStore, DropStore, PurgeStores). All other mutations are proxied to the DB cluster via `db.host` and replicated by the DB's own Raft cluster.
+- **Logging.** `ahnlich-ai` reads its log filter from `--log-level`, **not** `RUST_LOG`. Use `logLevel` for verbosity; `env`/`envFrom` for other process env.
+- **GPU.** The image ships the CUDA ONNX Runtime. Add `nvidia.com/gpu` to `resources.limits` and a matching `nodeSelector` to schedule on GPU nodes.
+
+The Service port advertises `appProtocol: grpc` for Ingress/Gateway controller auto-discovery. Enabling `ingress.enabled` and `gateway.enabled` together is a misconfiguration; the chart fails the install with an explicit error. See the `ahnlich-db` README for the controller-specific gRPC notes and external-access patterns — the surface is identical here.
+
+## Upgrading
+
+`helm upgrade my-ai charts/ahnlich-ai` rolls pods one at a time. PVCs (model cache and persistence data) survive the upgrade. In cluster mode, the PodDisruptionBudget (`maxUnavailable: 1`) keeps quorum intact.
+
+## Uninstalling
+
+```bash
+helm uninstall my-ai
+kubectl delete pvc -l app.kubernetes.io/instance=my-ai   # only if you also want to drop cached models / data
+```

--- a/charts/ahnlich-ai/templates/NOTES.txt
+++ b/charts/ahnlich-ai/templates/NOTES.txt
@@ -1,0 +1,21 @@
+In-cluster: {{ include "ahnlich-ai.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+Backing DB: {{ .Values.db.host }}:{{ .Values.db.port }}
+
+{{- if eq .Values.service.type "LoadBalancer" }}
+
+External (LoadBalancer): wait for an external IP, then connect on port {{ .Values.service.port }}:
+  kubectl -n {{ .Release.Namespace }} get svc {{ include "ahnlich-ai.fullname" . }}
+{{- else if .Values.ingress.enabled }}
+
+External (Ingress): {{ if .Values.ingress.host }}{{ .Values.ingress.host }}{{ else }}<your Ingress host>{{ end }}
+{{- else if .Values.gateway.enabled }}
+
+External (Gateway): check the address on the parent Gateway:
+{{- range .Values.gateway.parentRefs }}
+  kubectl get gateway {{ .name }}{{ if .namespace }} -n {{ .namespace }}{{ else }} -n {{ $.Release.Namespace }}{{ end }}
+{{- end }}
+{{- else }}
+
+External (port-forward): for ad-hoc local testing only.
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ahnlich-ai.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+{{- end }}

--- a/charts/ahnlich-ai/templates/_helpers.tpl
+++ b/charts/ahnlich-ai/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{- define "ahnlich-ai.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ahnlich-ai.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ahnlich-ai.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "ahnlich-ai.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: ai
+{{- end -}}
+
+{{/* Selector labels are the stable subset; changing them orphans existing pods. */}}
+{{- define "ahnlich-ai.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ahnlich-ai.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/ahnlich-ai/templates/_helpers.tpl
+++ b/charts/ahnlich-ai/templates/_helpers.tpl
@@ -29,3 +29,14 @@ app.kubernetes.io/component: ai
 app.kubernetes.io/name: {{ include "ahnlich-ai.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/* Effective pullPolicy: Always for :latest, IfNotPresent otherwise (unless user sets one). */}}
+{{- define "ahnlich-ai.pullPolicy" -}}
+{{- if .Values.image.pullPolicy -}}
+{{- .Values.image.pullPolicy -}}
+{{- else if eq (.Values.image.tag | default .Chart.AppVersion) "latest" -}}
+Always
+{{- else -}}
+IfNotPresent
+{{- end -}}
+{{- end -}}

--- a/charts/ahnlich-ai/templates/grpcroute.yaml
+++ b/charts/ahnlich-ai/templates/grpcroute.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+{{- fail "gateway.parentRefs must contain at least one Gateway reference when gateway.enabled=true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: {{ include "ahnlich-ai.fullname" . }}
+  labels:
+    {{- include "ahnlich-ai.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.gateway.parentRefs }}
+    - name: {{ required "gateway.parentRefs[].name is required" .name | quote }}
+      {{- if .namespace }}
+      namespace: {{ .namespace | quote }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName | quote }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "ahnlich-ai.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/ahnlich-ai/templates/ingress.yaml
+++ b/charts/ahnlich-ai/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.gateway.enabled }}
+{{- fail "ingress.enabled and gateway.enabled are mutually exclusive. Pick one." }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ahnlich-ai.fullname" . }}
+  labels:
+    {{- include "ahnlich-ai.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ required "ingress.host is required when ingress.tls.enabled=true" .Values.ingress.host | quote }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host | quote }}
+      {{- end }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "ahnlich-ai.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/ahnlich-ai/templates/poddisruptionbudget.yaml
+++ b/charts/ahnlich-ai/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.cluster.enabled .Values.cluster.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ahnlich-ai.fullname" . }}
+  labels:
+    {{- include "ahnlich-ai.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.cluster.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "ahnlich-ai.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ahnlich-ai/templates/poddisruptionbudget.yaml
+++ b/charts/ahnlich-ai/templates/poddisruptionbudget.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "ahnlich-ai.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.cluster.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.cluster.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
       {{- include "ahnlich-ai.selectorLabels" . | nindent 6 }}

--- a/charts/ahnlich-ai/templates/service-headless.yaml
+++ b/charts/ahnlich-ai/templates/service-headless.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.cluster.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ahnlich-ai.fullname" . }}-headless
+  labels:
+    {{- include "ahnlich-ai.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: cluster
+      port: {{ .Values.cluster.port }}
+      targetPort: cluster
+      protocol: TCP
+  selector:
+    {{- include "ahnlich-ai.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/ahnlich-ai/templates/service.yaml
+++ b/charts/ahnlich-ai/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ahnlich-ai.fullname" . }}
+  labels:
+    {{- include "ahnlich-ai.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: client
+      port: {{ .Values.service.port }}
+      targetPort: client
+      protocol: TCP
+      appProtocol: grpc        # hint for Ingress/Gateway controllers that this is gRPC (HTTP/2)
+  selector:
+    {{- include "ahnlich-ai.selectorLabels" . | nindent 4 }}

--- a/charts/ahnlich-ai/templates/statefulset.yaml
+++ b/charts/ahnlich-ai/templates/statefulset.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "ahnlich-ai.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/ahnlich-ai/templates/statefulset.yaml
+++ b/charts/ahnlich-ai/templates/statefulset.yaml
@@ -19,10 +19,32 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.db.waitForReady.enabled }}
+      # Block startup until the backing DB Service accepts TCP connections.
+      # The DB Service only routes to a pod once its readinessProbe passes,
+      # so an open port here means DB is at least PING-ready.
+      initContainers:
+        - name: wait-for-db
+          image: {{ .Values.db.waitForReady.image | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              DEADLINE=$(( $(date +%s) + {{ .Values.db.waitForReady.timeoutSeconds }} ))
+              until nc -z {{ required "db.host is required" .Values.db.host }} {{ .Values.db.port }}; do
+                if [ $(date +%s) -ge $DEADLINE ]; then
+                  echo "timed out waiting for {{ .Values.db.host }}:{{ .Values.db.port }}"
+                  exit 1
+                fi
+                echo "waiting for {{ .Values.db.host }}:{{ .Values.db.port }} ..."
+                sleep {{ .Values.db.waitForReady.intervalSeconds }}
+              done
+              echo "{{ .Values.db.host }}:{{ .Values.db.port }} is up"
+      {{- end }}
       containers:
         - name: ahnlich-ai
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ include "ahnlich-ai.pullPolicy" . }}
           {{- if .Values.cluster.enabled }}
           # Pod-0 on a fresh data dir bootstraps; pod-N (N>0) on a fresh data dir
           # joins via pod-0's headless DNS. Existing data dir means "recover" --

--- a/charts/ahnlich-ai/templates/statefulset.yaml
+++ b/charts/ahnlich-ai/templates/statefulset.yaml
@@ -1,26 +1,26 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "ahnlich-db.fullname" . }}
+  name: {{ include "ahnlich-ai.fullname" . }}
   labels:
-    {{- include "ahnlich-db.labels" . | nindent 4 }}
+    {{- include "ahnlich-ai.labels" . | nindent 4 }}
 spec:
-  serviceName: {{ include "ahnlich-db.fullname" . }}{{ if .Values.cluster.enabled }}-headless{{ end }}
+  serviceName: {{ include "ahnlich-ai.fullname" . }}{{ if .Values.cluster.enabled }}-headless{{ end }}
   replicas: {{ if .Values.cluster.enabled }}{{ .Values.cluster.replicas }}{{ else }}1{{ end }}
   selector:
     matchLabels:
-      {{- include "ahnlich-db.selectorLabels" . | nindent 6 }}
+      {{- include "ahnlich-ai.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "ahnlich-db.selectorLabels" . | nindent 8 }}
+        {{- include "ahnlich-ai.selectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: ahnlich-db
+        - name: ahnlich-ai
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.cluster.enabled }}
@@ -37,12 +37,15 @@ spec:
                 if [ "$ORDINAL" = "0" ]; then
                   CLUSTER_FLAG="--cluster-bootstrap"
                 else
-                  CLUSTER_FLAG="--cluster-join={{ include "ahnlich-db.fullname" . }}-0.{{ include "ahnlich-db.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.cluster.port }}"
+                  CLUSTER_FLAG="--cluster-join={{ include "ahnlich-ai.fullname" . }}-0.{{ include "ahnlich-ai.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.cluster.port }}"
                 fi
               fi
-              exec ahnlich-db run \
+              exec ahnlich-ai run \
                 --host=0.0.0.0 \
                 --port={{ .Values.service.port }} \
+                --db-host={{ required "db.host is required" .Values.db.host }} \
+                --db-port={{ .Values.db.port }} \
+                --supported-models={{ join "," .Values.models.supported }} \
                 --cluster-addr=0.0.0.0:{{ .Values.cluster.port }} \
                 --cluster-storage={{ .Values.cluster.storage }} \
                 --cluster-data-dir={{ .Values.cluster.dataDir }} \
@@ -57,11 +60,14 @@ spec:
                 {{- end }}
                 $CLUSTER_FLAG
           {{- else }}
-          command: ["ahnlich-db"]
+          command: ["ahnlich-ai"]
           args:
             - run
             - --host=0.0.0.0
             - --port={{ .Values.service.port }}
+            - --db-host={{ required "db.host is required" .Values.db.host }}
+            - --db-port={{ .Values.db.port }}
+            - --supported-models={{ join "," .Values.models.supported }}
             {{- if .Values.persistence.enabled }}
             - --enable-persistence
             - --persist-location={{ .Values.persistence.mountPath }}/{{ .Values.persistence.fileName }}
@@ -89,7 +95,7 @@ spec:
               command:
                 - sh
                 - -c
-                - "echo 'PING' | ahnlich-cli ahnlich --agent db --host 127.0.0.1 --port {{ .Values.service.port }} --no-interactive"
+                - "echo 'PING' | ahnlich-cli ahnlich --agent ai --host 127.0.0.1 --port {{ .Values.service.port }} --no-interactive"
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
@@ -99,16 +105,18 @@ spec:
               command:
                 - sh
                 - -c
-                - "echo 'PING' | ahnlich-cli ahnlich --agent db --host 127.0.0.1 --port {{ .Values.service.port }} --no-interactive"
+                - "echo 'PING' | ahnlich-cli ahnlich --agent ai --host 127.0.0.1 --port {{ .Values.service.port }} --no-interactive"
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
-          {{- if or .Values.persistence.enabled .Values.cluster.enabled }}
           volumeMounts:
+            - name: models
+              mountPath: {{ .Values.models.cache.mountPath }}
+            {{- if or .Values.persistence.enabled .Values.cluster.enabled }}
             - name: data
               mountPath: {{ if .Values.cluster.enabled }}{{ .Values.cluster.dataDir }}{{ else }}{{ .Values.persistence.mountPath }}{{ end }}
-          {{- end }}
+            {{- end }}
           {{- with .Values.env }}
           env:
             {{- toYaml . | nindent 12 }}
@@ -131,8 +139,18 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if or .Values.persistence.enabled .Values.cluster.enabled }}
   volumeClaimTemplates:
+    - metadata:
+        name: models
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.models.cache.storageClass }}
+        storageClassName: {{ .Values.models.cache.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.models.cache.size }}
+    {{- if or .Values.persistence.enabled .Values.cluster.enabled }}
     - metadata:
         name: data
       spec:
@@ -152,4 +170,4 @@ spec:
           requests:
             storage: {{ .Values.persistence.size }}
         {{- end }}
-  {{- end }}
+    {{- end }}

--- a/charts/ahnlich-ai/values.yaml
+++ b/charts/ahnlich-ai/values.yaml
@@ -1,12 +1,20 @@
 image:
   repository: ghcr.io/deven96/ahnlich-ai
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: ""                # empty: Always for :latest, IfNotPresent otherwise
 
 # Backing ahnlich-db connection. Required.
 db:
   host: ""                      # e.g. my-ahnlich-ahnlich-db.default.svc.cluster.local
   port: 1369
+  # Block AI pod startup with an initContainer until the DB Service port is open.
+  # Matches the docker-compose `depends_on: service_healthy` behaviour. Disable
+  # if DB is reachable from somewhere k8s doesn't know about (external host, etc.).
+  waitForReady:
+    enabled: true
+    image: busybox:1.36.1
+    timeoutSeconds: 300         # how long to keep retrying before giving up
+    intervalSeconds: 2
 
 # Embedding models served by this AI instance. Comma-joined into --supported-models.
 models:
@@ -33,7 +41,7 @@ cluster:
     storageClass: ""
   podDisruptionBudget:
     enabled: true
-    minAvailable: 2
+    maxUnavailable: 1           # tolerate one pod evicted at a time; scales with replicas
 
 service:
   type: ClusterIP

--- a/charts/ahnlich-ai/values.yaml
+++ b/charts/ahnlich-ai/values.yaml
@@ -1,101 +1,145 @@
 image:
+  # -- Image repository.
   repository: ghcr.io/deven96/ahnlich-ai
+  # -- Image tag.
   tag: latest
-  pullPolicy: ""                # empty: Always for :latest, IfNotPresent otherwise
+  # -- Pull policy. Empty selects `Always` for the `latest` tag, `IfNotPresent` otherwise.
+  pullPolicy: ""
 
-# Backing ahnlich-db connection. Required.
 db:
-  host: ""                      # e.g. my-ahnlich-ahnlich-db.default.svc.cluster.local
+  # -- DNS name of the backing ahnlich-db Service (required), e.g. `my-ahnlich-ahnlich-db`.
+  host: ""
+  # -- DB port.
   port: 1369
-  # Block AI pod startup with an initContainer until the DB Service port is open.
-  # Matches the docker-compose `depends_on: service_healthy` behaviour. Disable
-  # if DB is reachable from somewhere k8s doesn't know about (external host, etc.).
   waitForReady:
+    # -- Block AI startup with an initContainer until the DB Service port opens (mirrors docker-compose `depends_on: service_healthy`).
     enabled: true
+    # -- Image used for the wait probe (needs `nc`).
     image: busybox:1.36.1
-    timeoutSeconds: 300         # how long to keep retrying before giving up
+    # -- How long to keep retrying before failing the pod (s).
+    timeoutSeconds: 300
+    # -- Poll interval between port checks (s).
     intervalSeconds: 2
 
-# Embedding models served by this AI instance. Comma-joined into --supported-models.
 models:
+  # -- Model names served by this instance; comma-joined into `--supported-models`.
   supported:
     - all-minilm-l6-v2
     - resnet-50
-  # Persistent volume for the model cache. AI downloads models on first use and
-  # reuses them across restarts. Sized 20Gi by default; bump for larger model sets.
   cache:
+    # -- PVC size for the model cache.
     size: 20Gi
-    storageClass: ""            # uses the cluster's default StorageClass if empty
+    # -- StorageClass for the model cache. Empty uses the cluster default.
+    storageClass: ""
+    # -- In-container model cache path.
     mountPath: /root/.ahnlich/models
 
 cluster:
+  # -- Run N replicas as an AI-local Raft cluster instead of a single standalone node.
   enabled: false
+  # -- StatefulSet replica count in cluster mode.
   replicas: 3
-  port: 1371                    # --cluster-addr port for Raft RPCs
-  storage: rocksdb              # rocksdb | memory (memory is testing only, no durability)
-  dataDir: /root/.ahnlich/raft  # --cluster-data-dir (RocksDB log + snapshots)
-  snapshotLogs: 1000            # --cluster-snapshot-logs (count-based snapshot trigger)
-  snapshotIntervalMs: 300000    # --cluster-snapshot-interval (time-based trigger)
+  # -- `--cluster-addr` port for Raft RPCs.
+  port: 1371
+  # -- Raft storage backend: `rocksdb` (production) or `memory` (testing only, no durability).
+  storage: rocksdb
+  # -- `--cluster-data-dir` (RocksDB log + snapshots).
+  dataDir: /root/.ahnlich/raft
+  # -- `--cluster-snapshot-logs` count-based snapshot trigger.
+  snapshotLogs: 1000
+  # -- `--cluster-snapshot-interval` time-based snapshot trigger (ms).
+  snapshotIntervalMs: 300000
   persistence:
-    size: 10Gi                  # AI replicates only store metadata; logs grow slower than DB's
+    # -- PVC size for the Raft data dir (AI replicates only metadata, so logs grow slower than DB's).
+    size: 10Gi
+    # -- StorageClass for the Raft data dir. Empty uses the cluster default.
     storageClass: ""
   podDisruptionBudget:
+    # -- Create a PodDisruptionBudget in cluster mode.
     enabled: true
-    maxUnavailable: 1           # tolerate one pod evicted at a time; scales with replicas
+    # -- Pods that may be evicted at once; scales with replicas.
+    maxUnavailable: 1
 
 service:
+  # -- Service type: `ClusterIP`, `LoadBalancer`, or `NodePort`.
   type: ClusterIP
-  port: 1370                    # --port, the public client-facing port
+  # -- `--port`, the public client-facing gRPC port.
+  port: 1370
 
 ingress:
+  # -- Create an Ingress resource (requires an Ingress Controller in the cluster).
   enabled: false
+  # -- IngressClass name. Empty uses the cluster default.
   className: ""
+  # -- Hostname, e.g. `ai.example.com`. Required when `ingress.tls.enabled`.
   host: ""
+  # -- Path prefix.
   path: /
+  # -- Path type: `Prefix`, `Exact`, or `ImplementationSpecific`.
   pathType: Prefix
+  # -- Controller-specific annotations (e.g. nginx-ingress `backend-protocol: GRPC`).
   annotations: {}
   tls:
+    # -- Add a TLS block to the Ingress.
     enabled: false
+    # -- Name of an existing TLS Secret in this namespace.
     secretName: ""
 
 gateway:
+  # -- Create a GRPCRoute attached to an existing Gateway (mutually exclusive with `ingress`).
   enabled: false
+  # -- Existing Gateway references; `name` is required when `gateway.enabled`.
   parentRefs:
     - name: ""
       namespace: ""
       sectionName: ""
+  # -- Hostnames the route claims, e.g. `["ai.example.com"]`.
   hostnames: []
 
-# Standalone persistence of AI-local store metadata. Only used when cluster.enabled=false.
 persistence:
+  # -- Mount a PVC and pass `--enable-persistence` (standalone mode only).
   enabled: true
+  # -- PVC size for the AI-local metadata snapshot (small).
   size: 5Gi
+  # -- StorageClass for the snapshot PVC. Empty uses the cluster default.
   storageClass: ""
+  # -- In-container mount point for the snapshot.
   mountPath: /root/.ahnlich/data
+  # -- Snapshot file name.
   fileName: ai.dat
+  # -- `--persistence-interval` value (ms).
   intervalMs: 30000
 
 tracing:
+  # -- Pass `--enable-tracing` and `--otel-endpoint`.
   enabled: false
-  otelEndpoint: ""              # e.g. http://jaeger-collector:4317
+  # -- OTLP gRPC endpoint, e.g. `http://jaeger-collector:4317`.
+  otelEndpoint: ""
 
-# --log-level (env_logger / tracing-subscriber syntax). Empty = binary default ("info,hf_hub=warn").
+# -- `--log-level` (env_logger / tracing-subscriber syntax). Empty uses the binary default (`info,hf_hub=warn`).
 logLevel: ""
 
 probes:
   readiness:
+    # -- Readiness probe initial delay (s).
     initialDelaySeconds: 10
+    # -- Readiness probe period (s).
     periodSeconds: 10
+    # -- Readiness probe timeout (s).
     timeoutSeconds: 5
+    # -- Readiness probe failure threshold.
     failureThreshold: 3
   liveness:
+    # -- Liveness probe initial delay (s); higher default to cover first-run model download.
     initialDelaySeconds: 60
+    # -- Liveness probe period (s).
     periodSeconds: 30
+    # -- Liveness probe timeout (s).
     timeoutSeconds: 5
+    # -- Liveness probe failure threshold.
     failureThreshold: 3
 
-# AI is heavier than DB (ONNX model inference). Set requests/limits per workload.
-# GPU acceleration: add nvidia.com/gpu to limits and a matching nodeSelector.
+# -- Container resource requests/limits. AI is heavier than DB; for GPU add `nvidia.com/gpu` to limits plus a matching nodeSelector.
 resources: {}
 #   requests:
 #     cpu: 500m
@@ -105,12 +149,8 @@ resources: {}
 #     memory: 8Gi
 #     nvidia.com/gpu: 1
 
-# Extra environment variables. Use for Rust runtime knobs (RUST_LOG, RUST_BACKTRACE),
-# ORT_DYLIB_PATH for custom ONNX Runtime locations, or any other process env.
-# Supports name/value pairs and valueFrom (Secret/ConfigMap refs).
+# -- Extra environment variables (name/value or valueFrom). Use for `RUST_BACKTRACE`, `ORT_DYLIB_PATH`, etc.
 env: []
-#   - name: RUST_LOG
-#     value: debug
 #   - name: RUST_BACKTRACE
 #     value: "1"
 #   - name: SOME_SECRET
@@ -119,14 +159,20 @@ env: []
 #         name: my-secret
 #         key: token
 
-# Bulk-import env from ConfigMaps or Secrets.
+# -- Bulk-import env from ConfigMaps or Secrets.
 envFrom: []
 #   - configMapRef:
 #       name: ahnlich-config
 #   - secretRef:
 #       name: ahnlich-secrets
 
+# -- Node selector for pod scheduling.
 nodeSelector: {}
+# -- Tolerations for pod scheduling.
 tolerations: []
+# -- Affinity rules for pod scheduling.
 affinity: {}
+# -- Annotations added to the pod template.
 podAnnotations: {}
+# -- Extra labels added to the pod template (not the selector).
+podLabels: {}

--- a/charts/ahnlich-ai/values.yaml
+++ b/charts/ahnlich-ai/values.yaml
@@ -1,0 +1,124 @@
+image:
+  repository: ghcr.io/deven96/ahnlich-ai
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Backing ahnlich-db connection. Required.
+db:
+  host: ""                      # e.g. my-ahnlich-ahnlich-db.default.svc.cluster.local
+  port: 1369
+
+# Embedding models served by this AI instance. Comma-joined into --supported-models.
+models:
+  supported:
+    - all-minilm-l6-v2
+    - resnet-50
+  # Persistent volume for the model cache. AI downloads models on first use and
+  # reuses them across restarts. Sized 20Gi by default; bump for larger model sets.
+  cache:
+    size: 20Gi
+    storageClass: ""            # uses the cluster's default StorageClass if empty
+    mountPath: /root/.ahnlich/models
+
+cluster:
+  enabled: false
+  replicas: 3
+  port: 1371                    # --cluster-addr port for Raft RPCs
+  storage: rocksdb              # rocksdb | memory (memory is testing only, no durability)
+  dataDir: /root/.ahnlich/raft  # --cluster-data-dir (RocksDB log + snapshots)
+  snapshotLogs: 1000            # --cluster-snapshot-logs (count-based snapshot trigger)
+  snapshotIntervalMs: 300000    # --cluster-snapshot-interval (time-based trigger)
+  persistence:
+    size: 10Gi                  # AI replicates only store metadata; logs grow slower than DB's
+    storageClass: ""
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 2
+
+service:
+  type: ClusterIP
+  port: 1370                    # --port, the public client-facing port
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  path: /
+  pathType: Prefix
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+gateway:
+  enabled: false
+  parentRefs:
+    - name: ""
+      namespace: ""
+      sectionName: ""
+  hostnames: []
+
+# Standalone persistence of AI-local store metadata. Only used when cluster.enabled=false.
+persistence:
+  enabled: true
+  size: 5Gi
+  storageClass: ""
+  mountPath: /root/.ahnlich/data
+  fileName: ai.dat
+  intervalMs: 30000
+
+tracing:
+  enabled: false
+  otelEndpoint: ""              # e.g. http://jaeger-collector:4317
+
+# --log-level (env_logger / tracing-subscriber syntax). Empty = binary default ("info,hf_hub=warn").
+logLevel: ""
+
+probes:
+  readiness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  liveness:
+    initialDelaySeconds: 60
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# AI is heavier than DB (ONNX model inference). Set requests/limits per workload.
+# GPU acceleration: add nvidia.com/gpu to limits and a matching nodeSelector.
+resources: {}
+#   requests:
+#     cpu: 500m
+#     memory: 2Gi
+#   limits:
+#     cpu: 2000m
+#     memory: 8Gi
+#     nvidia.com/gpu: 1
+
+# Extra environment variables. Use for Rust runtime knobs (RUST_LOG, RUST_BACKTRACE),
+# ORT_DYLIB_PATH for custom ONNX Runtime locations, or any other process env.
+# Supports name/value pairs and valueFrom (Secret/ConfigMap refs).
+env: []
+#   - name: RUST_LOG
+#     value: debug
+#   - name: RUST_BACKTRACE
+#     value: "1"
+#   - name: SOME_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: token
+
+# Bulk-import env from ConfigMaps or Secrets.
+envFrom: []
+#   - configMapRef:
+#       name: ahnlich-config
+#   - secretRef:
+#       name: ahnlich-secrets
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}

--- a/charts/ahnlich-db/.helmignore
+++ b/charts/ahnlich-db/.helmignore
@@ -1,0 +1,7 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ahnlich-db/Chart.yaml
+++ b/charts/ahnlich-db/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: ahnlich-db
+description: Helm chart for ahnlich-db, the in-memory vector database
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/deven96/ahnlich
+sources:
+  - https://github.com/deven96/ahnlich
+keywords:
+  - vector-database
+  - similarity-search
+  - ahnlich

--- a/charts/ahnlich-db/README.md
+++ b/charts/ahnlich-db/README.md
@@ -1,0 +1,196 @@
+# ahnlich-db
+
+Helm chart for `ahnlich-db`, the in-memory vector database.
+
+The chart supports two deployment modes from a single chart, toggled by a values flag:
+
+- **Standalone** (default): single replica with periodic JSON-snapshot persistence. Suitable for development and single-node production.
+- **Cluster (Raft)**: N replicas forming a Raft cluster per the [replication spec](../../docs/specs/replication.md). Activate with `--set cluster.enabled=true`.
+
+## Prerequisites
+
+- Kubernetes 1.20+ (for `appProtocol: grpc` on the Service).
+- A default `StorageClass` in the cluster (the chart falls back to it unless overridden).
+- Optional, only if you want external L7 access:
+  - An Ingress Controller (nginx-ingress, Traefik, etc.) for the Ingress path.
+  - A Gateway API implementation (Envoy Gateway, Contour, etc.) plus an existing `Gateway` resource for the Gateway path.
+
+The chart does **not** bundle an Ingress Controller or a Gateway implementation — those are cluster-wide infrastructure.
+
+## Quick start
+
+```bash
+# Standalone, in-cluster access only
+helm install my-ahnlich charts/ahnlich-db
+
+# Standalone, exposed externally via a cloud LoadBalancer
+helm install my-ahnlich charts/ahnlich-db --set service.type=LoadBalancer
+
+# With tracing pointed at an existing OTLP collector
+helm install my-ahnlich charts/ahnlich-db \
+  --set tracing.enabled=true \
+  --set tracing.otelEndpoint=http://jaeger-collector:4317
+```
+
+## Values
+
+### Image
+
+| Key | Default | Description |
+|---|---|---|
+| `image.repository` | `ghcr.io/deven96/ahnlich-db` | Image repository. |
+| `image.tag` | `latest` | Image tag. |
+| `image.pullPolicy` | `IfNotPresent` | Standard k8s pull policy. |
+
+### Service
+
+| Key | Default | Description |
+|---|---|---|
+| `service.type` | `ClusterIP` | One of `ClusterIP`, `LoadBalancer`, `NodePort`. |
+| `service.port` | `1369` | Public client-facing gRPC port. |
+
+The Service port advertises `appProtocol: grpc` so modern Ingress / Gateway controllers auto-configure HTTP/2 to the backend without per-controller annotations.
+
+### Standalone persistence
+
+| Key | Default | Description |
+|---|---|---|
+| `persistence.enabled` | `true` | Mount a PVC at `mountPath` and pass `--enable-persistence`. |
+| `persistence.size` | `10Gi` | PVC size for the JSON snapshot file. |
+| `persistence.storageClass` | `""` | StorageClass name; empty = cluster default. |
+| `persistence.mountPath` | `/root/.ahnlich/data` | In-container mount point. |
+| `persistence.fileName` | `db.dat` | Snapshot file name. |
+| `persistence.intervalMs` | `30000` | `--persistence-interval` value in ms. |
+
+Automatically suppressed when `cluster.enabled=true` (Raft snapshots and log replication replace standalone persistence).
+
+### Cluster (Raft) mode
+
+| Key | Default | Description |
+|---|---|---|
+| `cluster.enabled` | `false` | Run N replicas as a Raft cluster. |
+| `cluster.replicas` | `3` | StatefulSet replica count. |
+| `cluster.port` | `1370` | `--cluster-addr` port for Raft RPCs. |
+| `cluster.storage` | `rocksdb` | `rocksdb` (production) or `memory` (testing only). |
+| `cluster.dataDir` | `/root/.ahnlich/raft` | `--cluster-data-dir`. |
+| `cluster.snapshotLogs` | `1000` | Count-based snapshot trigger. |
+| `cluster.snapshotIntervalMs` | `300000` | Time-based snapshot trigger. |
+| `cluster.persistence.size` | `20Gi` | PVC size for the Raft data dir. |
+| `cluster.persistence.storageClass` | `""` | StorageClass name; empty = cluster default. |
+| `cluster.podDisruptionBudget.enabled` | `true` | Protect quorum during voluntary disruptions. |
+| `cluster.podDisruptionBudget.minAvailable` | `2` | Minimum pods that must stay up. |
+
+When enabled, the chart also creates a headless Service for pod DNS resolution (Raft peer discovery) and a PodDisruptionBudget.
+
+The shell-wrapper in the StatefulSet args derives `--cluster-bootstrap` for pod-0 (when its data dir is empty) and `--cluster-join` for higher ordinals pointing at pod-0's headless DNS name. Restarts of existing pods leave both flags off so the binary recovers from the persisted Raft log (`ClusterLifecycle::Existing`).
+
+### Tracing
+
+| Key | Default | Description |
+|---|---|---|
+| `tracing.enabled` | `false` | Pass `--enable-tracing --otel-endpoint=...`. |
+| `tracing.otelEndpoint` | `""` | OTLP gRPC endpoint (e.g. `http://jaeger-collector:4317`). |
+
+The chart does not deploy a tracing backend. Point `tracing.otelEndpoint` at any OTLP-compatible receiver: Jaeger, Tempo, an OpenTelemetry Collector, Honeycomb, etc.
+
+### Ingress (optional)
+
+| Key | Default | Description |
+|---|---|---|
+| `ingress.enabled` | `false` | Create an `Ingress` resource. |
+| `ingress.className` | `""` | IngressClass name; empty = cluster default. |
+| `ingress.host` | `""` | Required if `ingress.tls.enabled=true`. |
+| `ingress.path` | `/` | Path prefix. |
+| `ingress.pathType` | `Prefix` | One of `Prefix`, `Exact`, `ImplementationSpecific`. |
+| `ingress.annotations` | `{}` | Controller-specific annotations (see below). |
+| `ingress.tls.enabled` | `false` | Add a `tls` block. |
+| `ingress.tls.secretName` | `""` | Name of an existing TLS Secret. |
+
+Controller-specific gRPC notes:
+
+- **nginx-ingress**: add `nginx.ingress.kubernetes.io/backend-protocol: GRPC` to `ingress.annotations`. The chart's `appProtocol: grpc` is the standard hint but older nginx versions ignore it.
+- **Traefik**: as Ingress Controller, requires service annotation `traefik.ingress.kubernetes.io/service.serversscheme: h2c` for plaintext gRPC. For TLS-terminating gRPC, defaults work.
+
+### Gateway API (optional, mutually exclusive with Ingress)
+
+| Key | Default | Description |
+|---|---|---|
+| `gateway.enabled` | `false` | Create a `GRPCRoute` attached to an existing Gateway. |
+| `gateway.parentRefs` | `[{name: "", ...}]` | Existing Gateway references; `name` is required when enabled. |
+| `gateway.hostnames` | `[]` | Hostnames the route claims. |
+
+The chart only ships the `GRPCRoute`. The `Gateway` itself is cluster-level and must be created out-of-band (typically by your platform team).
+
+Enabling `ingress.enabled` and `gateway.enabled` simultaneously is a misconfiguration; the chart fails the install with an explicit error.
+
+### Pod scheduling
+
+| Key | Default | Description |
+|---|---|---|
+| `resources` | `{}` | Container `resources` block (requests/limits). |
+| `nodeSelector` | `{}` | Schedule on nodes matching these labels. |
+| `tolerations` | `[]` | Tolerate node taints. |
+| `affinity` | `{}` | Pod / node affinity rules. |
+| `podAnnotations` | `{}` | Free-form annotations on the pod template. |
+
+### Probes
+
+`probes.readiness.*` and `probes.liveness.*` accept the standard k8s timing fields: `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`. Both probes run `ahnlich-cli PING` against the local pod.
+
+## External access patterns
+
+Three ways to expose the DB to clients outside the cluster, in increasing order of features:
+
+1. **`service.type=LoadBalancer`** — one external IP per Service, L4 only. Simplest. Cheap in single-app deployments, expensive at scale (one cloud LB per Service).
+2. **`ingress.enabled=true`** — single shared edge router (the Ingress Controller) fans out to many apps. Adds TLS termination, hostname routing, controller-specific policies. Requires an Ingress Controller in the cluster.
+3. **`gateway.enabled=true`** — same idea as Ingress with a cleaner, role-split API (Gateway API). Adds first-class gRPC matching (`GRPCRoute` can match on service + method). Requires a Gateway API implementation in the cluster.
+
+For in-cluster service-to-service traffic (e.g. `ahnlich-ai` calling `ahnlich-db`), leave `service.type=ClusterIP` and reach the DB at `<release>-ahnlich-db.<namespace>.svc.cluster.local`. No external access needed.
+
+## Example: attach to an existing Envoy Gateway
+
+```bash
+# Cluster-level: GatewayClass + Gateway already exist
+kubectl get gatewayclass eg
+kubectl -n ahnlich get gateway eg
+
+# Install the chart attached to the Gateway
+helm install ahnlich charts/ahnlich-db \
+  --namespace ahnlich \
+  --set gateway.enabled=true \
+  --set gateway.parentRefs[0].name=eg \
+  --set gateway.hostnames[0]=ahnlich-db.example.com
+```
+
+The chart's GRPCRoute attaches to the Gateway named `eg` in the same namespace. The Gateway's external address becomes the route's address.
+
+## Example: attach to an existing nginx-ingress
+
+```bash
+helm install ahnlich charts/ahnlich-db \
+  --namespace ahnlich \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.host=ahnlich-db.example.com \
+  --set 'ingress.annotations.nginx\.ingress\.kubernetes\.io/backend-protocol=GRPC' \
+  --set ingress.tls.enabled=true \
+  --set ingress.tls.secretName=ahnlich-db-tls
+```
+
+## Upgrading
+
+`helm upgrade my-ahnlich charts/ahnlich-db` re-renders against the new values and applies the diff. The StatefulSet's pods are rolled one at a time. The PVC survives the upgrade (PVCs are not deleted by Helm).
+
+In cluster mode, an upgrade rolls one pod at a time; with the PodDisruptionBudget at `minAvailable: 2`, quorum stays intact through the upgrade.
+
+## Uninstalling
+
+```bash
+helm uninstall my-ahnlich
+```
+
+PVCs are not deleted automatically (Helm intentionally leaves them; data deletion is destructive). Clean them up with:
+
+```bash
+kubectl delete pvc -l app.kubernetes.io/instance=my-ahnlich
+```

--- a/charts/ahnlich-db/README.md
+++ b/charts/ahnlich-db/README.md
@@ -123,6 +123,23 @@ The chart only ships the `GRPCRoute`. The `Gateway` itself is cluster-level and 
 
 Enabling `ingress.enabled` and `gateway.enabled` simultaneously is a misconfiguration; the chart fails the install with an explicit error.
 
+### Logging
+
+| Key | Default | Description |
+|---|---|---|
+| `logLevel` | `""` | Sets `--log-level` on the binary. Empty = the binary's default (`info,hf_hub=warn`). Example values: `debug`, `trace`, `info,ahnlich_db=debug`. |
+
+`ahnlich-db` reads its log filter from `--log-level`, **not** from `RUST_LOG`. Setting `RUST_LOG` via `env` has no effect.
+
+### Environment variables
+
+| Key | Default | Description |
+|---|---|---|
+| `env` | `[]` | List of `EnvVar` entries (`name/value` or `valueFrom`). |
+| `envFrom` | `[]` | List of `EnvFromSource` entries (`configMapRef` or `secretRef`). |
+
+For Rust runtime knobs not exposed as flags (`RUST_BACKTRACE=1`, etc.) or any other process env. Both keys take the standard k8s shape, so anything you can put in a Pod's `env`/`envFrom` works here. For log verbosity use `logLevel` above instead.
+
 ### Pod scheduling
 
 | Key | Default | Description |

--- a/charts/ahnlich-db/README.md.gotmpl
+++ b/charts/ahnlich-db/README.md.gotmpl
@@ -32,62 +32,7 @@ helm install my-ahnlich charts/ahnlich-db \
   --set tracing.otelEndpoint=http://jaeger-collector:4317
 ```
 
-## Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` | Affinity rules for pod scheduling. |
-| cluster.dataDir | string | `"/root/.ahnlich/raft"` | `--cluster-data-dir` (RocksDB log + snapshots). |
-| cluster.enabled | bool | `false` | Run N replicas as a Raft cluster instead of a single standalone node. |
-| cluster.persistence.size | string | `"20Gi"` | PVC size for the Raft data dir (larger default: logs grow faster than periodic snapshots). |
-| cluster.persistence.storageClass | string | `""` | StorageClass for the Raft data dir. Empty uses the cluster default. |
-| cluster.podDisruptionBudget.enabled | bool | `true` | Create a PodDisruptionBudget in cluster mode. |
-| cluster.podDisruptionBudget.maxUnavailable | int | `1` | Pods that may be evicted at once; scales with replicas. |
-| cluster.port | int | `1370` | `--cluster-addr` port for Raft RPCs. |
-| cluster.replicas | int | `3` | StatefulSet replica count in cluster mode. |
-| cluster.snapshotIntervalMs | int | `300000` | `--cluster-snapshot-interval` time-based snapshot trigger (ms). |
-| cluster.snapshotLogs | int | `1000` | `--cluster-snapshot-logs` count-based snapshot trigger. |
-| cluster.storage | string | `"rocksdb"` | Raft storage backend: `rocksdb` (production) or `memory` (testing only, no durability). |
-| env | list | `[]` | Extra environment variables (name/value or valueFrom). Use for Rust runtime knobs like `RUST_BACKTRACE`. |
-| envFrom | list | `[]` | Bulk-import env from ConfigMaps or Secrets. |
-| gateway.enabled | bool | `false` | Create a GRPCRoute attached to an existing Gateway (mutually exclusive with `ingress`). |
-| gateway.hostnames | list | `[]` | Hostnames the route claims, e.g. `["ahnlich-db.example.com"]`. |
-| gateway.parentRefs | list | `[{"name":"","namespace":"","sectionName":""}]` | Existing Gateway references; `name` is required when `gateway.enabled`. |
-| image.pullPolicy | string | `""` | Pull policy. Empty selects `Always` for the `latest` tag, `IfNotPresent` otherwise. |
-| image.repository | string | `"ghcr.io/deven96/ahnlich-db"` | Image repository. |
-| image.tag | string | `"latest"` | Image tag. |
-| ingress.annotations | object | `{}` | Controller-specific annotations (e.g. nginx-ingress `backend-protocol: GRPC`). |
-| ingress.className | string | `""` | IngressClass name. Empty uses the cluster default. |
-| ingress.enabled | bool | `false` | Create an Ingress resource (requires an Ingress Controller in the cluster). |
-| ingress.host | string | `""` | Hostname, e.g. `ahnlich-db.example.com`. Required when `ingress.tls.enabled`. |
-| ingress.path | string | `"/"` | Path prefix. |
-| ingress.pathType | string | `"Prefix"` | Path type: `Prefix`, `Exact`, or `ImplementationSpecific`. |
-| ingress.tls.enabled | bool | `false` | Add a TLS block to the Ingress. |
-| ingress.tls.secretName | string | `""` | Name of an existing TLS Secret in this namespace. |
-| logLevel | string | `""` | `--log-level` (env_logger / tracing-subscriber syntax). Empty uses the binary default (`info,hf_hub=warn`). |
-| nodeSelector | object | `{}` | Node selector for pod scheduling. |
-| persistence.enabled | bool | `true` | Mount a PVC and pass `--enable-persistence` (standalone mode only). |
-| persistence.fileName | string | `"db.dat"` | Snapshot file name. |
-| persistence.intervalMs | int | `30000` | `--persistence-interval` value (ms). |
-| persistence.mountPath | string | `"/root/.ahnlich/data"` | In-container mount point for the snapshot. |
-| persistence.size | string | `"10Gi"` | PVC size for the JSON snapshot file. |
-| persistence.storageClass | string | `""` | StorageClass for the snapshot PVC. Empty uses the cluster default. |
-| podAnnotations | object | `{}` | Annotations added to the pod template. |
-| podLabels | object | `{}` | Extra labels added to the pod template (not the selector). |
-| probes.liveness.failureThreshold | int | `3` | Liveness probe failure threshold. |
-| probes.liveness.initialDelaySeconds | int | `30` | Liveness probe initial delay (s). |
-| probes.liveness.periodSeconds | int | `30` | Liveness probe period (s). |
-| probes.liveness.timeoutSeconds | int | `5` | Liveness probe timeout (s). |
-| probes.readiness.failureThreshold | int | `3` | Readiness probe failure threshold. |
-| probes.readiness.initialDelaySeconds | int | `5` | Readiness probe initial delay (s). |
-| probes.readiness.periodSeconds | int | `10` | Readiness probe period (s). |
-| probes.readiness.timeoutSeconds | int | `5` | Readiness probe timeout (s). |
-| resources | object | `{}` | Container resource requests/limits. |
-| service.port | int | `1369` | `--port`, the public client-facing gRPC port. |
-| service.type | string | `"ClusterIP"` | Service type: `ClusterIP`, `LoadBalancer`, or `NodePort`. |
-| tolerations | list | `[]` | Tolerations for pod scheduling. |
-| tracing.enabled | bool | `false` | Pass `--enable-tracing` and `--otel-endpoint`. |
-| tracing.otelEndpoint | string | `""` | OTLP gRPC endpoint, e.g. `http://jaeger-collector:4317`. |
+{{ template "chart.valuesSection" . }}
 
 The Service port advertises `appProtocol: grpc` so modern Ingress / Gateway controllers auto-configure HTTP/2 to the backend without per-controller annotations.
 

--- a/charts/ahnlich-db/templates/NOTES.txt
+++ b/charts/ahnlich-db/templates/NOTES.txt
@@ -1,0 +1,20 @@
+In-cluster: {{ include "ahnlich-db.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+{{- if eq .Values.service.type "LoadBalancer" }}
+
+External (LoadBalancer): wait for an external IP, then connect on port {{ .Values.service.port }}:
+  kubectl -n {{ .Release.Namespace }} get svc {{ include "ahnlich-db.fullname" . }}
+{{- else if .Values.ingress.enabled }}
+
+External (Ingress): {{ if .Values.ingress.host }}{{ .Values.ingress.host }}{{ else }}<your Ingress host>{{ end }}
+{{- else if .Values.gateway.enabled }}
+
+External (Gateway): check the address on the parent Gateway:
+{{- range .Values.gateway.parentRefs }}
+  kubectl get gateway {{ .name }}{{ if .namespace }} -n {{ .namespace }}{{ else }} -n {{ $.Release.Namespace }}{{ end }}
+{{- end }}
+{{- else }}
+
+External (port-forward): for ad-hoc local testing only.
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ahnlich-db.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+{{- end }}

--- a/charts/ahnlich-db/templates/_helpers.tpl
+++ b/charts/ahnlich-db/templates/_helpers.tpl
@@ -29,3 +29,14 @@ app.kubernetes.io/component: database
 app.kubernetes.io/name: {{ include "ahnlich-db.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/* Effective pullPolicy: Always for :latest, IfNotPresent otherwise (unless user sets one). */}}
+{{- define "ahnlich-db.pullPolicy" -}}
+{{- if .Values.image.pullPolicy -}}
+{{- .Values.image.pullPolicy -}}
+{{- else if eq (.Values.image.tag | default .Chart.AppVersion) "latest" -}}
+Always
+{{- else -}}
+IfNotPresent
+{{- end -}}
+{{- end -}}

--- a/charts/ahnlich-db/templates/_helpers.tpl
+++ b/charts/ahnlich-db/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{- define "ahnlich-db.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ahnlich-db.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ahnlich-db.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "ahnlich-db.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: database
+{{- end -}}
+
+{{/* Selector labels are the stable subset; changing them orphans existing pods. */}}
+{{- define "ahnlich-db.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ahnlich-db.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/ahnlich-db/templates/grpcroute.yaml
+++ b/charts/ahnlich-db/templates/grpcroute.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.gateway.enabled }}
+{{- if not .Values.gateway.parentRefs }}
+{{- fail "gateway.parentRefs must contain at least one Gateway reference when gateway.enabled=true" }}
+{{- end }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: {{ include "ahnlich-db.fullname" . }}
+  labels:
+    {{- include "ahnlich-db.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.gateway.parentRefs }}
+    - name: {{ required "gateway.parentRefs[].name is required" .name | quote }}
+      {{- if .namespace }}
+      namespace: {{ .namespace | quote }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName | quote }}
+      {{- end }}
+    {{- end }}
+  {{- with .Values.gateway.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "ahnlich-db.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/ahnlich-db/templates/ingress.yaml
+++ b/charts/ahnlich-db/templates/ingress.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.gateway.enabled }}
+{{- fail "ingress.enabled and gateway.enabled are mutually exclusive. Pick one." }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ahnlich-db.fullname" . }}
+  labels:
+    {{- include "ahnlich-db.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ required "ingress.host is required when ingress.tls.enabled=true" .Values.ingress.host | quote }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host | quote }}
+      {{- end }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "ahnlich-db.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/ahnlich-db/templates/poddisruptionbudget.yaml
+++ b/charts/ahnlich-db/templates/poddisruptionbudget.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "ahnlich-db.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.cluster.podDisruptionBudget.minAvailable }}
+  maxUnavailable: {{ .Values.cluster.podDisruptionBudget.maxUnavailable }}
   selector:
     matchLabels:
       {{- include "ahnlich-db.selectorLabels" . | nindent 6 }}

--- a/charts/ahnlich-db/templates/poddisruptionbudget.yaml
+++ b/charts/ahnlich-db/templates/poddisruptionbudget.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.cluster.enabled .Values.cluster.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ahnlich-db.fullname" . }}
+  labels:
+    {{- include "ahnlich-db.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.cluster.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "ahnlich-db.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ahnlich-db/templates/service-headless.yaml
+++ b/charts/ahnlich-db/templates/service-headless.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.cluster.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ahnlich-db.fullname" . }}-headless
+  labels:
+    {{- include "ahnlich-db.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: cluster
+      port: {{ .Values.cluster.port }}
+      targetPort: cluster
+      protocol: TCP
+  selector:
+    {{- include "ahnlich-db.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/ahnlich-db/templates/service.yaml
+++ b/charts/ahnlich-db/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ahnlich-db.fullname" . }}
+  labels:
+    {{- include "ahnlich-db.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: client
+      port: {{ .Values.service.port }}
+      targetPort: client
+      protocol: TCP
+      appProtocol: grpc        # hint for Ingress/Gateway controllers that this is gRPC (HTTP/2)
+  selector:
+    {{- include "ahnlich-db.selectorLabels" . | nindent 4 }}

--- a/charts/ahnlich-db/templates/statefulset.yaml
+++ b/charts/ahnlich-db/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: ahnlich-db
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          imagePullPolicy: {{ include "ahnlich-db.pullPolicy" . }}
           {{- if .Values.cluster.enabled }}
           # Pod-0 on a fresh data dir bootstraps; pod-N (N>0) on a fresh data dir
           # joins via pod-0's headless DNS. Existing data dir means "recover" --

--- a/charts/ahnlich-db/templates/statefulset.yaml
+++ b/charts/ahnlich-db/templates/statefulset.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "ahnlich-db.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/ahnlich-db/templates/statefulset.yaml
+++ b/charts/ahnlich-db/templates/statefulset.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ahnlich-db.fullname" . }}
+  labels:
+    {{- include "ahnlich-db.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "ahnlich-db.fullname" . }}{{ if .Values.cluster.enabled }}-headless{{ end }}
+  replicas: {{ if .Values.cluster.enabled }}{{ .Values.cluster.replicas }}{{ else }}1{{ end }}
+  selector:
+    matchLabels:
+      {{- include "ahnlich-db.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ahnlich-db.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: ahnlich-db
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.cluster.enabled }}
+          # Pod-0 on a fresh data dir bootstraps; pod-N (N>0) on a fresh data dir
+          # joins via pod-0's headless DNS. Existing data dir means "recover" --
+          # no flag is added so openraft picks ClusterLifecycle::Existing.
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+              ORDINAL="${HOSTNAME##*-}"
+              CLUSTER_FLAG=""
+              if [ -z "$(ls -A {{ .Values.cluster.dataDir }} 2>/dev/null)" ]; then
+                if [ "$ORDINAL" = "0" ]; then
+                  CLUSTER_FLAG="--cluster-bootstrap"
+                else
+                  CLUSTER_FLAG="--cluster-join={{ include "ahnlich-db.fullname" . }}-0.{{ include "ahnlich-db.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.cluster.port }}"
+                fi
+              fi
+              exec ahnlich-db run \
+                --host=0.0.0.0 \
+                --port={{ .Values.service.port }} \
+                --cluster-addr=0.0.0.0:{{ .Values.cluster.port }} \
+                --cluster-storage={{ .Values.cluster.storage }} \
+                --cluster-data-dir={{ .Values.cluster.dataDir }} \
+                --cluster-snapshot-logs={{ .Values.cluster.snapshotLogs }} \
+                --cluster-snapshot-interval={{ .Values.cluster.snapshotIntervalMs }} \
+                {{- if .Values.tracing.enabled }}
+                --enable-tracing \
+                --otel-endpoint={{ .Values.tracing.otelEndpoint }} \
+                {{- end }}
+                $CLUSTER_FLAG
+          {{- else }}
+          command: ["ahnlich-db"]
+          args:
+            - run
+            - --host=0.0.0.0
+            - --port={{ .Values.service.port }}
+            {{- if .Values.persistence.enabled }}
+            - --enable-persistence
+            - --persist-location={{ .Values.persistence.mountPath }}/{{ .Values.persistence.fileName }}
+            - --persistence-interval={{ .Values.persistence.intervalMs }}
+            {{- end }}
+            {{- if .Values.tracing.enabled }}
+            - --enable-tracing
+            - --otel-endpoint={{ .Values.tracing.otelEndpoint }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: client
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            {{- if .Values.cluster.enabled }}
+            - name: cluster
+              containerPort: {{ .Values.cluster.port }}
+              protocol: TCP
+            {{- end }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "echo 'PING' | ahnlich-cli ahnlich --agent db --host 127.0.0.1 --port {{ .Values.service.port }} --no-interactive"
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - "echo 'PING' | ahnlich-cli ahnlich --agent db --host 127.0.0.1 --port {{ .Values.service.port }} --no-interactive"
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- if or .Values.persistence.enabled .Values.cluster.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ if .Values.cluster.enabled }}{{ .Values.cluster.dataDir }}{{ else }}{{ .Values.persistence.mountPath }}{{ end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if or .Values.persistence.enabled .Values.cluster.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.cluster.enabled }}
+        {{- if .Values.cluster.persistence.storageClass }}
+        storageClassName: {{ .Values.cluster.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.cluster.persistence.size }}
+        {{- else }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{- end }}
+  {{- end }}

--- a/charts/ahnlich-db/values.yaml
+++ b/charts/ahnlich-db/values.yaml
@@ -1,73 +1,117 @@
 image:
+  # -- Image repository.
   repository: ghcr.io/deven96/ahnlich-db
+  # -- Image tag.
   tag: latest
-  pullPolicy: ""                # empty: Always for :latest, IfNotPresent otherwise
+  # -- Pull policy. Empty selects `Always` for the `latest` tag, `IfNotPresent` otherwise.
+  pullPolicy: ""
 
 cluster:
+  # -- Run N replicas as a Raft cluster instead of a single standalone node.
   enabled: false
+  # -- StatefulSet replica count in cluster mode.
   replicas: 3
-  port: 1370                    # --cluster-addr port for Raft RPCs
-  storage: rocksdb              # rocksdb | memory (memory is testing only, no durability)
-  dataDir: /root/.ahnlich/raft  # --cluster-data-dir (RocksDB log + snapshots)
-  snapshotLogs: 1000            # --cluster-snapshot-logs (count-based snapshot trigger)
-  snapshotIntervalMs: 300000    # --cluster-snapshot-interval (time-based trigger)
+  # -- `--cluster-addr` port for Raft RPCs.
+  port: 1370
+  # -- Raft storage backend: `rocksdb` (production) or `memory` (testing only, no durability).
+  storage: rocksdb
+  # -- `--cluster-data-dir` (RocksDB log + snapshots).
+  dataDir: /root/.ahnlich/raft
+  # -- `--cluster-snapshot-logs` count-based snapshot trigger.
+  snapshotLogs: 1000
+  # -- `--cluster-snapshot-interval` time-based snapshot trigger (ms).
+  snapshotIntervalMs: 300000
   persistence:
-    size: 20Gi                  # larger default: Raft logs grow faster than periodic snapshots
-    storageClass: ""            # uses the cluster's default StorageClass if empty
+    # -- PVC size for the Raft data dir (larger default: logs grow faster than periodic snapshots).
+    size: 20Gi
+    # -- StorageClass for the Raft data dir. Empty uses the cluster default.
+    storageClass: ""
   podDisruptionBudget:
+    # -- Create a PodDisruptionBudget in cluster mode.
     enabled: true
-    maxUnavailable: 1           # tolerate one pod evicted at a time; scales with replicas
+    # -- Pods that may be evicted at once; scales with replicas.
+    maxUnavailable: 1
 
 service:
+  # -- Service type: `ClusterIP`, `LoadBalancer`, or `NodePort`.
   type: ClusterIP
-  port: 1369                    # --port, the public client-facing port
+  # -- `--port`, the public client-facing gRPC port.
+  port: 1369
 
 ingress:
+  # -- Create an Ingress resource (requires an Ingress Controller in the cluster).
   enabled: false
-  className: ""                 # IngressClass name. Empty = cluster default.
-  host: ""                      # e.g. ahnlich-db.example.com
+  # -- IngressClass name. Empty uses the cluster default.
+  className: ""
+  # -- Hostname, e.g. `ahnlich-db.example.com`. Required when `ingress.tls.enabled`.
+  host: ""
+  # -- Path prefix.
   path: /
+  # -- Path type: `Prefix`, `Exact`, or `ImplementationSpecific`.
   pathType: Prefix
-  annotations: {}               # controller-specific knobs (e.g. nginx-ingress backend-protocol GRPC)
+  # -- Controller-specific annotations (e.g. nginx-ingress `backend-protocol: GRPC`).
+  annotations: {}
   tls:
+    # -- Add a TLS block to the Ingress.
     enabled: false
-    secretName: ""              # name of an existing TLS Secret in this namespace
+    # -- Name of an existing TLS Secret in this namespace.
+    secretName: ""
 
 gateway:
+  # -- Create a GRPCRoute attached to an existing Gateway (mutually exclusive with `ingress`).
   enabled: false
+  # -- Existing Gateway references; `name` is required when `gateway.enabled`.
   parentRefs:
-    - name: ""                  # required when gateway.enabled=true; the Gateway resource name
-      namespace: ""             # optional; defaults to this release's namespace
-      sectionName: ""           # optional; pin to a specific Gateway listener
-  hostnames: []                 # e.g. ["ahnlich-db.example.com"]
+    - name: ""
+      namespace: ""
+      sectionName: ""
+  # -- Hostnames the route claims, e.g. `["ahnlich-db.example.com"]`.
+  hostnames: []
 
 persistence:
+  # -- Mount a PVC and pass `--enable-persistence` (standalone mode only).
   enabled: true
+  # -- PVC size for the JSON snapshot file.
   size: 10Gi
-  storageClass: ""              # uses the cluster's default StorageClass if empty
+  # -- StorageClass for the snapshot PVC. Empty uses the cluster default.
+  storageClass: ""
+  # -- In-container mount point for the snapshot.
   mountPath: /root/.ahnlich/data
+  # -- Snapshot file name.
   fileName: db.dat
+  # -- `--persistence-interval` value (ms).
   intervalMs: 30000
 
 tracing:
+  # -- Pass `--enable-tracing` and `--otel-endpoint`.
   enabled: false
-  otelEndpoint: ""              # e.g. http://jaeger-collector:4317
+  # -- OTLP gRPC endpoint, e.g. `http://jaeger-collector:4317`.
+  otelEndpoint: ""
 
-# --log-level (env_logger / tracing-subscriber syntax). Empty = binary default ("info,hf_hub=warn").
+# -- `--log-level` (env_logger / tracing-subscriber syntax). Empty uses the binary default (`info,hf_hub=warn`).
 logLevel: ""
 
 probes:
   readiness:
+    # -- Readiness probe initial delay (s).
     initialDelaySeconds: 5
+    # -- Readiness probe period (s).
     periodSeconds: 10
+    # -- Readiness probe timeout (s).
     timeoutSeconds: 5
+    # -- Readiness probe failure threshold.
     failureThreshold: 3
   liveness:
+    # -- Liveness probe initial delay (s).
     initialDelaySeconds: 30
+    # -- Liveness probe period (s).
     periodSeconds: 30
+    # -- Liveness probe timeout (s).
     timeoutSeconds: 5
+    # -- Liveness probe failure threshold.
     failureThreshold: 3
 
+# -- Container resource requests/limits.
 resources: {}
 #   requests:
 #     cpu: 100m
@@ -76,11 +120,8 @@ resources: {}
 #     cpu: 1000m
 #     memory: 2Gi
 
-# Extra environment variables. Use for Rust runtime knobs (RUST_LOG, RUST_BACKTRACE)
-# or any other process env. Supports name/value pairs and valueFrom (Secret/ConfigMap refs).
+# -- Extra environment variables (name/value or valueFrom). Use for Rust runtime knobs like `RUST_BACKTRACE`.
 env: []
-#   - name: RUST_LOG
-#     value: debug
 #   - name: RUST_BACKTRACE
 #     value: "1"
 #   - name: SOME_SECRET
@@ -89,14 +130,20 @@ env: []
 #         name: my-secret
 #         key: token
 
-# Bulk-import env from ConfigMaps or Secrets.
+# -- Bulk-import env from ConfigMaps or Secrets.
 envFrom: []
 #   - configMapRef:
 #       name: ahnlich-config
 #   - secretRef:
 #       name: ahnlich-secrets
 
+# -- Node selector for pod scheduling.
 nodeSelector: {}
+# -- Tolerations for pod scheduling.
 tolerations: []
+# -- Affinity rules for pod scheduling.
 affinity: {}
+# -- Annotations added to the pod template.
 podAnnotations: {}
+# -- Extra labels added to the pod template (not the selector).
+podLabels: {}

--- a/charts/ahnlich-db/values.yaml
+++ b/charts/ahnlich-db/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: ghcr.io/deven96/ahnlich-db
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: ""                # empty: Always for :latest, IfNotPresent otherwise
 
 cluster:
   enabled: false
@@ -16,7 +16,7 @@ cluster:
     storageClass: ""            # uses the cluster's default StorageClass if empty
   podDisruptionBudget:
     enabled: true
-    minAvailable: 2             # never allow fewer than 2 of 3 pods during voluntary disruptions
+    maxUnavailable: 1           # tolerate one pod evicted at a time; scales with replicas
 
 service:
   type: ClusterIP

--- a/charts/ahnlich-db/values.yaml
+++ b/charts/ahnlich-db/values.yaml
@@ -53,6 +53,9 @@ tracing:
   enabled: false
   otelEndpoint: ""              # e.g. http://jaeger-collector:4317
 
+# --log-level (env_logger / tracing-subscriber syntax). Empty = binary default ("info,hf_hub=warn").
+logLevel: ""
+
 probes:
   readiness:
     initialDelaySeconds: 5
@@ -72,6 +75,26 @@ resources: {}
 #   limits:
 #     cpu: 1000m
 #     memory: 2Gi
+
+# Extra environment variables. Use for Rust runtime knobs (RUST_LOG, RUST_BACKTRACE)
+# or any other process env. Supports name/value pairs and valueFrom (Secret/ConfigMap refs).
+env: []
+#   - name: RUST_LOG
+#     value: debug
+#   - name: RUST_BACKTRACE
+#     value: "1"
+#   - name: SOME_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: token
+
+# Bulk-import env from ConfigMaps or Secrets.
+envFrom: []
+#   - configMapRef:
+#       name: ahnlich-config
+#   - secretRef:
+#       name: ahnlich-secrets
 
 nodeSelector: {}
 tolerations: []

--- a/charts/ahnlich-db/values.yaml
+++ b/charts/ahnlich-db/values.yaml
@@ -1,0 +1,79 @@
+image:
+  repository: ghcr.io/deven96/ahnlich-db
+  tag: latest
+  pullPolicy: IfNotPresent
+
+cluster:
+  enabled: false
+  replicas: 3
+  port: 1370                    # --cluster-addr port for Raft RPCs
+  storage: rocksdb              # rocksdb | memory (memory is testing only, no durability)
+  dataDir: /root/.ahnlich/raft  # --cluster-data-dir (RocksDB log + snapshots)
+  snapshotLogs: 1000            # --cluster-snapshot-logs (count-based snapshot trigger)
+  snapshotIntervalMs: 300000    # --cluster-snapshot-interval (time-based trigger)
+  persistence:
+    size: 20Gi                  # larger default: Raft logs grow faster than periodic snapshots
+    storageClass: ""            # uses the cluster's default StorageClass if empty
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 2             # never allow fewer than 2 of 3 pods during voluntary disruptions
+
+service:
+  type: ClusterIP
+  port: 1369                    # --port, the public client-facing port
+
+ingress:
+  enabled: false
+  className: ""                 # IngressClass name. Empty = cluster default.
+  host: ""                      # e.g. ahnlich-db.example.com
+  path: /
+  pathType: Prefix
+  annotations: {}               # controller-specific knobs (e.g. nginx-ingress backend-protocol GRPC)
+  tls:
+    enabled: false
+    secretName: ""              # name of an existing TLS Secret in this namespace
+
+gateway:
+  enabled: false
+  parentRefs:
+    - name: ""                  # required when gateway.enabled=true; the Gateway resource name
+      namespace: ""             # optional; defaults to this release's namespace
+      sectionName: ""           # optional; pin to a specific Gateway listener
+  hostnames: []                 # e.g. ["ahnlich-db.example.com"]
+
+persistence:
+  enabled: true
+  size: 10Gi
+  storageClass: ""              # uses the cluster's default StorageClass if empty
+  mountPath: /root/.ahnlich/data
+  fileName: db.dat
+  intervalMs: 30000
+
+tracing:
+  enabled: false
+  otelEndpoint: ""              # e.g. http://jaeger-collector:4317
+
+probes:
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  liveness:
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+resources: {}
+#   requests:
+#     cpu: 100m
+#     memory: 256Mi
+#   limits:
+#     cpu: 1000m
+#     memory: 2Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}

--- a/charts/ahnlich/.helmignore
+++ b/charts/ahnlich/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git/
+.gitignore
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ahnlich/Chart.lock
+++ b/charts/ahnlich/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: ahnlich-db
+  repository: file://../ahnlich-db
+  version: 0.1.0
+- name: ahnlich-ai
+  repository: file://../ahnlich-ai
+  version: 0.1.0
+digest: sha256:9fef0cb0e428b3be662c5d26a80804f8a49ff33f9ff87387ba6eff52a8bb643e
+generated: "2026-05-20T20:37:38.592968+02:00"

--- a/charts/ahnlich/Chart.yaml
+++ b/charts/ahnlich/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: ahnlich
+description: Umbrella chart that deploys ahnlich-db and ahnlich-ai together with optional tracing backend.
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/deven96/ahnlich
+sources:
+  - https://github.com/deven96/ahnlich
+keywords:
+  - vector-database
+  - embeddings
+  - ahnlich
+
+dependencies:
+  - name: ahnlich-db
+    version: "0.1.0"
+    repository: "file://../ahnlich-db"
+  - name: ahnlich-ai
+    version: "0.1.0"
+    repository: "file://../ahnlich-ai"

--- a/charts/ahnlich/README.md
+++ b/charts/ahnlich/README.md
@@ -1,0 +1,133 @@
+# ahnlich
+
+Umbrella Helm chart that deploys [`ahnlich-db`](../ahnlich-db/) and [`ahnlich-ai`](../ahnlich-ai/) together, pre-wired so the AI talks to the DB out of the box. Optionally deploys an in-cluster OTLP tracing backend (Jaeger by default; image is configurable for other OTLP receivers).
+
+## Quick start
+
+The release name must be `ahnlich` for the default DB host wiring to resolve. To use a different release name, also override `ahnlich-ai.db.host`.
+
+```bash
+# Build sub-chart dependencies (one time, after cloning)
+helm dependency build charts/ahnlich
+
+# Standalone DB + AI
+helm install ahnlich charts/ahnlich
+
+# Cluster (Raft) mode for both
+helm install ahnlich charts/ahnlich \
+  --set ahnlich-db.cluster.enabled=true \
+  --set ahnlich-ai.cluster.enabled=true
+
+# DB in cluster mode, AI standalone (mix-and-match is fine)
+helm install ahnlich charts/ahnlich \
+  --set ahnlich-db.cluster.enabled=true
+
+# With the in-cluster tracing backend (defaults to Jaeger all-in-one)
+helm install ahnlich charts/ahnlich \
+  --set tracing.enabled=true \
+  --set tracing.backend.enabled=true \
+  --set ahnlich-db.tracing.enabled=true \
+  --set ahnlich-ai.tracing.enabled=true
+```
+
+For real deployments, a `-f values-prod.yaml` file is friendlier than chaining `--set`.
+
+## Pattern
+
+The umbrella is a thin aggregator: it declares `ahnlich-db` and `ahnlich-ai` as sub-chart dependencies and forwards values into them under their respective namespaces. Every sub-chart toggle remains independently controllable:
+
+```yaml
+# values.yaml
+ahnlich-db:
+  cluster:
+    enabled: true
+  service:
+    type: LoadBalancer
+ahnlich-ai:
+  cluster:
+    enabled: false       # mixed mode is fine
+  db:
+    host: ahnlich-ahnlich-db
+  models:
+    supported: [all-minilm-l6-v2, resnet-50, clip-vit-b32-text]
+```
+
+This is intentional — debugging or running mixed configurations (DB clustered, AI standalone for testing, etc.) is a normal part of the workflow.
+
+## Values
+
+### Top-level (umbrella's own resources)
+
+| Key | Default | Description |
+|---|---|---|
+| `tracing.enabled` | `false` | Master switch for any tracing wiring. Setting this alone does nothing until at least one of `tracing.backend.enabled` or per-sub-chart `tracing.enabled` is also set. |
+| `tracing.backend.enabled` | `false` | Deploy an in-cluster OTLP receiver as a Deployment + Service. |
+| `tracing.backend.image.repository` | `jaegertracing/all-in-one` | Default backend image. Override for other OTLP receivers. |
+| `tracing.backend.image.tag` | `latest` | |
+| `tracing.backend.env` | `[{COLLECTOR_OTLP_ENABLED: "true"}]` | Backend container env. The default is Jaeger-shaped. |
+| `tracing.backend.ports.otlp` | `4317` | OTLP gRPC port that ahnlich-db / ahnlich-ai send to. |
+| `tracing.backend.ports.ui` | `16686` | Browser UI port (Jaeger default). |
+| `tracing.backend.service.type` | `ClusterIP` | |
+
+The backend's Service is named `<release>-tracing-backend`. With the default release name `ahnlich`, that resolves to `ahnlich-tracing-backend`, which is what `ahnlich-db.tracing.otelEndpoint` and `ahnlich-ai.tracing.otelEndpoint` default to.
+
+### Sub-chart values
+
+Set anything from the [`ahnlich-db`](../ahnlich-db/README.md) or [`ahnlich-ai`](../ahnlich-ai/README.md) charts via the namespaced key:
+
+```bash
+--set ahnlich-db.<key>=<value>
+--set ahnlich-ai.<key>=<value>
+```
+
+Pre-wired defaults in the umbrella's `values.yaml`:
+
+- `ahnlich-ai.db.host` → `ahnlich-ahnlich-db` (the DB Service name when release is `ahnlich`).
+- `ahnlich-db.tracing.otelEndpoint` → `http://ahnlich-tracing-backend:4317`.
+- `ahnlich-ai.tracing.otelEndpoint` → `http://ahnlich-tracing-backend:4317`.
+
+To enable tracing per-sub-chart, override `tracing.enabled` under each:
+
+```bash
+--set ahnlich-db.tracing.enabled=true
+--set ahnlich-ai.tracing.enabled=true
+```
+
+### Using a non-`ahnlich` release name
+
+The DB Service is named `<release>-ahnlich-db`. If you install as `foo`, override the AI's `db.host`:
+
+```bash
+helm install foo charts/ahnlich \
+  --set ahnlich-ai.db.host=foo-ahnlich-db
+```
+
+The post-install message will warn you when the release name doesn't match `ahnlich`.
+
+## External access
+
+The umbrella does not impose a global external-access pattern. Each sub-chart's `service.type`, `ingress.*`, and `gateway.*` blocks work independently. Typically you only expose `ahnlich-ai` externally (it sits in front of `ahnlich-db`):
+
+```bash
+helm install ahnlich charts/ahnlich \
+  --set ahnlich-ai.service.type=LoadBalancer
+# or
+helm install ahnlich charts/ahnlich \
+  --set ahnlich-ai.gateway.enabled=true \
+  --set 'ahnlich-ai.gateway.parentRefs[0].name=my-gateway'
+```
+
+## Operational notes
+
+- **The bundled tracing backend is dev/demo only.** Jaeger all-in-one runs as a single replica with in-memory span storage, no auth, and `:latest`. For anything beyond local poking, set `tracing.backend.enabled=false` and point `ahnlich-db.tracing.otelEndpoint` / `ahnlich-ai.tracing.otelEndpoint` at your own OTLP collector (Tempo, Honeycomb, vendor SDK, etc.).
+- **TLS for Ingress.** Most gRPC clients reject plaintext HTTP/2 on a public hostname; enable `ingress.tls` (and bring a cert via cert-manager or a manual Secret) for any non-local install.
+- **Sub-chart version bumps need `helm dependency update`.** The umbrella declares `ahnlich-db` and `ahnlich-ai` by version. When you bump either sub-chart's `Chart.yaml` `version:`, run `helm dependency update charts/ahnlich` to refresh `Chart.lock` and re-vendor.
+- **Toggling `persistence.enabled` between upgrades fails.** StatefulSet `volumeClaimTemplates` is immutable; flipping persistence on/off requires `helm uninstall` then re-install (which orphans PVCs by default — clean them up via `kubectl delete pvc -l app.kubernetes.io/instance=<release>`).
+- **`:latest` and `imagePullPolicy`.** When `image.tag=latest`, the chart sets `imagePullPolicy: Always` so `helm upgrade` actually pulls the latest digest. Tagged versions default to `IfNotPresent`. Override `image.pullPolicy` per sub-chart to force either.
+
+## Uninstalling
+
+```bash
+helm uninstall ahnlich
+kubectl delete pvc -l app.kubernetes.io/instance=ahnlich   # drops cached models and persistence
+```

--- a/charts/ahnlich/README.md.gotmpl
+++ b/charts/ahnlich/README.md.gotmpl
@@ -38,25 +38,7 @@ The umbrella is a thin aggregator: it declares `ahnlich-db` and `ahnlich-ai` as 
 
 Set anything from the [`ahnlich-db`](../ahnlich-db/README.md) or [`ahnlich-ai`](../ahnlich-ai/README.md) charts via the namespaced key: `--set ahnlich-db.<key>=<value>` or `--set ahnlich-ai.<key>=<value>`.
 
-## Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| ahnlich-ai.db.host | string | `"ahnlich-ahnlich-db"` | DB Service name (auto-wired; assumes release name "ahnlich"). |
-| ahnlich-ai.db.port | int | `1369` | DB port. |
-| ahnlich-ai.tracing.enabled | bool | `false` | Send AI traces to the bundled backend. |
-| ahnlich-ai.tracing.otelEndpoint | string | `"http://ahnlich-tracing-backend:4317"` | OTLP endpoint (pre-wired to the bundled backend Service for release name "ahnlich"). |
-| ahnlich-db.tracing.enabled | bool | `false` | Send DB traces to the bundled backend. |
-| ahnlich-db.tracing.otelEndpoint | string | `"http://ahnlich-tracing-backend:4317"` | OTLP endpoint (pre-wired to the bundled backend Service for release name "ahnlich"). |
-| tracing.backend.enabled | bool | `false` | Deploy an in-cluster OTLP backend (Deployment + Service). |
-| tracing.backend.env | list | `[{"name":"COLLECTOR_OTLP_ENABLED","value":"true"}]` | Backend container env. Default is Jaeger-shaped. |
-| tracing.backend.image.pullPolicy | string | `"IfNotPresent"` | Backend image pull policy. |
-| tracing.backend.image.repository | string | `"jaegertracing/all-in-one"` | Backend image repository (default Jaeger all-in-one; swap for other OTLP receivers). |
-| tracing.backend.image.tag | string | `"latest"` | Backend image tag. |
-| tracing.backend.ports.otlp | int | `4317` | OTLP gRPC port the sub-charts send to. |
-| tracing.backend.ports.ui | int | `16686` | Browser UI port. |
-| tracing.backend.service.type | string | `"ClusterIP"` | Backend Service type. |
-| tracing.enabled | bool | `false` | Master switch for tracing wiring. Does nothing alone; pair with `tracing.backend.enabled` and/or per-sub-chart `tracing.enabled`. |
+{{ template "chart.valuesSection" . }}
 
 The backend's Service is named `<release>-tracing-backend`. With the default release name `ahnlich`, that resolves to `ahnlich-tracing-backend`, which is what the pre-wired `otelEndpoint` defaults point at. Install under a different name and you must override both `ahnlich-ai.db.host` and the `otelEndpoint`s — the chart fails at template time with the exact override command if you don't.
 

--- a/charts/ahnlich/templates/NOTES.txt
+++ b/charts/ahnlich/templates/NOTES.txt
@@ -1,0 +1,10 @@
+{{- include "ahnlich.validateReleaseName" . -}}
+ahnlich {{ .Chart.AppVersion }} deployed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Components:
+  ahnlich-db: {{ .Release.Name }}-ahnlich-db.{{ .Release.Namespace }}.svc.cluster.local:{{ index .Values "ahnlich-db" "service" "port" | default 1369 }}
+  ahnlich-ai: {{ .Release.Name }}-ahnlich-ai.{{ .Release.Namespace }}.svc.cluster.local:{{ index .Values "ahnlich-ai" "service" "port" | default 1370 }}
+{{- if and .Values.tracing.enabled .Values.tracing.backend.enabled }}
+  tracing UI: kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ahnlich.tracingBackendName" . }} {{ .Values.tracing.backend.ports.ui }}:{{ .Values.tracing.backend.ports.ui }}
+{{- end }}
+

--- a/charts/ahnlich/templates/_helpers.tpl
+++ b/charts/ahnlich/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{- define "ahnlich.tracingBackendName" -}}
+{{- printf "%s-tracing-backend" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ahnlich.tracingBackendLabels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: tracing-backend
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: tracing
+{{- end -}}
+
+{{- define "ahnlich.tracingBackendSelectorLabels" -}}
+app.kubernetes.io/name: tracing-backend
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/ahnlich/templates/_validate.tpl
+++ b/charts/ahnlich/templates/_validate.tpl
@@ -1,0 +1,22 @@
+{{- /*
+Release name is pinned to "ahnlich" so the umbrella's hard-coded sub-chart
+defaults (ahnlich-ai.db.host=ahnlich-ahnlich-db, tracing endpoints pointing
+at ahnlich-tracing-backend) resolve. Users who want a different release name
+must override the pinned defaults explicitly; this fail catches the common
+case where they did neither.
+*/ -}}
+{{- define "ahnlich.validateReleaseName" -}}
+{{- if ne .Release.Name "ahnlich" -}}
+{{- $expectedDbHost := printf "%s-ahnlich-db" .Release.Name -}}
+{{- $expectedTracing := printf "http://%s-tracing-backend:4317" .Release.Name -}}
+{{- $aiDbHost := index .Values "ahnlich-ai" "db" "host" -}}
+{{- $aiTracing := index .Values "ahnlich-ai" "tracing" "otelEndpoint" -}}
+{{- $dbTracing := index .Values "ahnlich-db" "tracing" "otelEndpoint" -}}
+{{- if eq $aiDbHost "ahnlich-ahnlich-db" -}}
+{{- fail (printf "Release name is %q, not \"ahnlich\". The umbrella's default ahnlich-ai.db.host points at \"ahnlich-ahnlich-db\" which will not resolve. Override with --set ahnlich-ai.db.host=%s" .Release.Name $expectedDbHost) -}}
+{{- end -}}
+{{- if and (index .Values "tracing" "backend" "enabled") (or (eq $aiTracing "http://ahnlich-tracing-backend:4317") (eq $dbTracing "http://ahnlich-tracing-backend:4317")) -}}
+{{- fail (printf "Release name is %q, not \"ahnlich\". The tracing backend Service will be %q but the sub-chart otelEndpoints still point at \"http://ahnlich-tracing-backend:4317\". Override ahnlich-db.tracing.otelEndpoint and ahnlich-ai.tracing.otelEndpoint to %s" .Release.Name (printf "%s-tracing-backend" .Release.Name) $expectedTracing) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/ahnlich/templates/tracing-backend.yaml
+++ b/charts/ahnlich/templates/tracing-backend.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.tracing.enabled .Values.tracing.backend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ahnlich.tracingBackendName" . }}
+  labels:
+    {{- include "ahnlich.tracingBackendLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ahnlich.tracingBackendSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ahnlich.tracingBackendSelectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: tracing-backend
+          image: "{{ .Values.tracing.backend.image.repository }}:{{ .Values.tracing.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.tracing.backend.image.pullPolicy }}
+          {{- with .Values.tracing.backend.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: otlp
+              containerPort: {{ .Values.tracing.backend.ports.otlp }}
+              protocol: TCP
+            - name: ui
+              containerPort: {{ .Values.tracing.backend.ports.ui }}
+              protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ahnlich.tracingBackendName" . }}
+  labels:
+    {{- include "ahnlich.tracingBackendLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.tracing.backend.service.type }}
+  selector:
+    {{- include "ahnlich.tracingBackendSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: otlp
+      port: {{ .Values.tracing.backend.ports.otlp }}
+      targetPort: otlp
+      protocol: TCP
+    - name: ui
+      port: {{ .Values.tracing.backend.ports.ui }}
+      targetPort: ui
+      protocol: TCP
+{{- end }}

--- a/charts/ahnlich/values.yaml
+++ b/charts/ahnlich/values.yaml
@@ -6,35 +6,47 @@
 # the name "ahnlich" so the DB Service resolves to "ahnlich-ahnlich-db". To use
 # a different release name, also override ahnlich-ai.db.host accordingly.
 
-# Top-level tracing toggles for the umbrella's own resources (the optional
-# in-cluster backend). Sub-chart tracing is controlled per sub-chart below.
 tracing:
+  # -- Master switch for tracing wiring. Does nothing alone; pair with `tracing.backend.enabled` and/or per-sub-chart `tracing.enabled`.
   enabled: false
   backend:
-    enabled: false             # deploy the in-cluster tracing backend Deployment + Service
+    # -- Deploy an in-cluster OTLP backend (Deployment + Service).
+    enabled: false
     image:
+      # -- Backend image repository (default Jaeger all-in-one; swap for other OTLP receivers).
       repository: jaegertracing/all-in-one
+      # -- Backend image tag.
       tag: latest
+      # -- Backend image pull policy.
       pullPolicy: IfNotPresent
-    # Defaults below are Jaeger-shaped; override env / ports / image for other OTLP receivers.
+    # -- Backend container env. Default is Jaeger-shaped.
     env:
       - name: COLLECTOR_OTLP_ENABLED
         value: "true"
     ports:
-      otlp: 4317               # what ahnlich-db / ahnlich-ai send to
-      ui: 16686                # web UI for browsing traces
+      # -- OTLP gRPC port the sub-charts send to.
+      otlp: 4317
+      # -- Browser UI port.
+      ui: 16686
     service:
+      # -- Backend Service type.
       type: ClusterIP
 
 ahnlich-db:
   tracing:
-    enabled: false             # set true to send traces to ahnlich-tracing-backend below
+    # -- Send DB traces to the bundled backend.
+    enabled: false
+    # -- OTLP endpoint (pre-wired to the bundled backend Service for release name "ahnlich").
     otelEndpoint: http://ahnlich-tracing-backend:4317
 
 ahnlich-ai:
   db:
-    host: ahnlich-ahnlich-db   # auto-wired; assumes release name "ahnlich"
+    # -- DB Service name (auto-wired; assumes release name "ahnlich").
+    host: ahnlich-ahnlich-db
+    # -- DB port.
     port: 1369
   tracing:
+    # -- Send AI traces to the bundled backend.
     enabled: false
+    # -- OTLP endpoint (pre-wired to the bundled backend Service for release name "ahnlich").
     otelEndpoint: http://ahnlich-tracing-backend:4317

--- a/charts/ahnlich/values.yaml
+++ b/charts/ahnlich/values.yaml
@@ -1,0 +1,40 @@
+# Umbrella defaults. Sub-chart blocks below are forwarded into each sub-chart
+# under its own values namespace; override via the sub-chart key, e.g.
+#   --set ahnlich-db.cluster.enabled=true
+#
+# Auto-wiring of ahnlich-ai -> ahnlich-db assumes the release is installed under
+# the name "ahnlich" so the DB Service resolves to "ahnlich-ahnlich-db". To use
+# a different release name, also override ahnlich-ai.db.host accordingly.
+
+# Top-level tracing toggles for the umbrella's own resources (the optional
+# in-cluster backend). Sub-chart tracing is controlled per sub-chart below.
+tracing:
+  enabled: false
+  backend:
+    enabled: false             # deploy the in-cluster tracing backend Deployment + Service
+    image:
+      repository: jaegertracing/all-in-one
+      tag: latest
+      pullPolicy: IfNotPresent
+    # Defaults below are Jaeger-shaped; override env / ports / image for other OTLP receivers.
+    env:
+      - name: COLLECTOR_OTLP_ENABLED
+        value: "true"
+    ports:
+      otlp: 4317               # what ahnlich-db / ahnlich-ai send to
+      ui: 16686                # web UI for browsing traces
+    service:
+      type: ClusterIP
+
+ahnlich-db:
+  tracing:
+    enabled: false             # set true to send traces to ahnlich-tracing-backend below
+    otelEndpoint: http://ahnlich-tracing-backend:4317
+
+ahnlich-ai:
+  db:
+    host: ahnlich-ahnlich-db   # auto-wired; assumes release name "ahnlich"
+    port: 1369
+  tracing:
+    enabled: false
+    otelEndpoint: http://ahnlich-tracing-backend:4317


### PR DESCRIPTION
Closes #272.

## Summary

Adds three Helm charts under `charts/` for deploying ahnlich on Kubernetes:

- **`charts/ahnlich-db/`** — StatefulSet, Service, optional headless Service + PodDisruptionBudget for cluster mode, optional Ingress, optional Gateway API `GRPCRoute`. Supports standalone (one replica + JSON snapshot persistence) and Raft cluster modes via a single `cluster.enabled` toggle.
- **`charts/ahnlich-ai/`** — same shape as DB, plus required `db.host` wiring, a dedicated PVC for the model cache, an `initContainer` that blocks startup until the DB Service is reachable (matching docker-compose's `depends_on: service_healthy`), and `--agent ai` on probes.
- **`charts/ahnlich/`** — umbrella that aggregates the two sub-charts and pre-wires `ahnlich-ai.db.host` to the DB Service when installed with release name `ahnlich`. Optionally deploys an in-cluster OTLP tracing backend (Jaeger all-in-one by default, image-swappable for any OTLP receiver) for the demo/local path. Template-time `fail` guards the pinned-release-name footgun with an explicit override command.

## Architecture decisions

- **Pattern A values forwarding** (explicit per-sub-chart blocks like `--set ahnlich-db.cluster.enabled=true`, no `global:` magic). Verbose but transparent; allows mixed configurations (DB via Gateway, AI via Ingress, or any combination).
- **No bundled Ingress Controller or Gateway implementation.** Charts ship `Ingress` and `GRPCRoute` resource templates only; controllers are cluster-wide infrastructure managed by platform teams.
- **M2-ready cluster mode.** The chart renders correct YAML when `cluster.enabled=true`. Once the ahnlich binary wires the `--cluster-*` flags (replication milestone M2), the same chart deploys without changes. Until then, enabling cluster mode crashes the pod at the binary level with `unknown argument '--cluster-addr'` — verified.
- **Logging via `--log-level` CLI flag, not `RUST_LOG`.** Chart exposes `logLevel` value that maps to the flag (ahnlich doesn't read `RUST_LOG`). `env`/`envFrom` blocks are separate for other process env.
- **Image pull policy auto-switches to `Always` for `:latest`** so `helm upgrade` actually rolls. Tagged versions use `IfNotPresent`.

## What was verified live on Rancher Desktop

| Scenario | Result |
|---|---|
| `helm install charts/ahnlich-db` standalone | DB up, PVC bound, PING via `--agent db` succeeds |
| `service.type=LoadBalancer` external access | External IP assigned, no port-forward needed |
| Tracing enabled + in-cluster Jaeger | Traces visible in Jaeger UI |
| `helm install charts/ahnlich-ai` pointed at DB | AI up, CREATESTORE flows AI → DB, store visible from both sides |
| `helm install charts/ahnlich` umbrella, standalone | DB + AI up, initContainer waits for DB, zero AI restarts |
| Gateway API path via Envoy Gateway + GRPCRoute | gRPC PING through `192.168.64.4:8080` → PONG |
| `helm install charts/ahnlich` cluster mode | Pod crashes at the binary as expected (M1 limitation, documented) |
| Release name mismatch + missing override | `helm install` fails at template time with override command |

## Notes

- Sub-chart dependencies use local `file://` paths; run `helm dependency build charts/ahnlich` after cloning before installing.
- README in each chart directory covers values reference, external access patterns, and operational caveats (TLS recommendation, VCT immutability with persistence toggle, sub-chart version bump workflow).