### PR TITLE
chore(release): cosmetic version bump for db/ai/cli binaries (UPSERT)

### DIFF
--- a/ahnlich/Cargo.lock
+++ b/ahnlich/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "ai"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ahnlich_client_rs",
  "ahnlich_types",
@@ -961,7 +961,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "ahnlich_client_rs",
  "ahnlich_types",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "db"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "ahash 0.8.12",
  "ahnlich-replication",

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 # only used for rust client test and not to be released

--- a/ahnlich/cli/Cargo.toml
+++ b/ahnlich/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [[bin]]

--- a/ahnlich/db/Cargo.toml
+++ b/ahnlich/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 
 [features]


### PR DESCRIPTION
Cosmetic version-label bump ahead of cutting the db/ai/cli binary releases. **No behavioral change** — it only sets the version string the binaries compile in and self-report.

- `db` 0.2.2 → **0.3.0**
- `ai` 0.3.0 → **0.4.0**
- `cli` 0.2.1 → **0.3.0**

The binaries report their version from `Cargo.toml` (`env!("CARGO_PKG_VERSION")`) via `--version` and the server INFO/PING response, whereas `release.yml` labels the Docker image / release asset from the git tag. Bumping keeps the two in sync so e.g. `ahnlich-db:0.3.0` reports `0.3.0` instead of the old `0.2.2`. Purely a label; no logic changes.

No workflow watches these files, so merging is inert on its own — the actual releases (`bin/db/0.3.0`, `bin/ai/0.4.0`, `bin/cli/0.3.0`) are created manually afterward.