### PR TITLE
chore(charts): bump charts to 0.1.1 (activate ArtifactHub verified publisher)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,49 @@
+# Releasing Ahnlich
+
+Every artifact releases the same way: **bump its version, merge, and CI (or one manual step) publishes it.** You can never re-release an existing version — always bump to a new one.
+
+## Surfaces
+
+| Artifact | Version file | Publishes to | Trigger |
+|---|---|---|---|
+| `ahnlich_types` + `ahnlich_client_rs` | `ahnlich/client/Cargo.toml` (+ `ahnlich/types/Cargo.toml`) | crates.io | PR merge |
+| `ahnlich-client-py` | `sdk/ahnlich-client-py/VERSION` | PyPI | PR merge |
+| `ahnlich-client-node` | `sdk/ahnlich-client-node/package.json` | npm | PR merge |
+| `ahnlich-db` / `ahnlich-ai` / `ahnlich-cli` | `ahnlich/<db\|ai\|cli>/Cargo.toml` | GitHub Releases + ghcr (db/ai) | manual GitHub Release |
+| Helm charts | `charts/<name>/Chart.yaml` | `oci://ghcr.io/deven96/charts` → ArtifactHub | PR merge |
+
+## Bump rules
+
+New feature → **minor**. Bug fix → **patch**. Breaking change → **major**.
+
+A **wire-protocol change** (`ahnlich/types` or `protos/`) is lockstep: bump `types`, `client-rs`, `db`, `ai`, and `python` together, plus `node` if its generated code changed. `types` and `client-rs` publish together to crates.io, so both must bump.
+
+## Release a client (rust / python / node)
+
+1. Bump the version file.
+2. Open a PR and merge to `main`.
+3. CI tags and publishes automatically. Confirm the new version on the registry.
+
+## Release a binary (db / ai / cli)
+
+1. Bump `ahnlich/<name>/Cargo.toml`, then merge. This keeps the binary's self-reported `--version` correct; it does not create a tag.
+2. Create a GitHub Release with tag `bin/<name>/<version>` and hand-written notes.
+3. `release.yml` builds the binaries and pushes Docker images (db and ai only; cli has no image).
+
+## Release a Helm chart
+
+1. Bump `charts/<name>/Chart.yaml` `version`, then merge.
+2. `charts-release.yml` packages and pushes the changed charts to `oci://ghcr.io/deven96/charts`.
+3. ArtifactHub reindexes automatically.
+
+First-time setup only: run the **Publish Helm charts** workflow manually, set the three ghcr packages to Public, and register `oci://ghcr.io/deven96/charts` on artifacthub.io.
+
+## Gotchas
+
+- Clients publish only when the watched version line changes in a **merged** PR.
+- Binaries publish only from a **GitHub Release**, never a bare tag.
+- ghcr package pages always show the repo README — per-image READMEs are a GitHub limitation, not a bug.
+
+## Current versions
+
+`types` / `client-rs` / `client-py` / `client-node` 0.4.0 · `db` 0.3.0 · `ai` 0.4.0 · `cli` 0.3.0 · charts 0.1.0

--- a/charts/ahnlich-ai/Chart.yaml
+++ b/charts/ahnlich-ai/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ahnlich-ai
 description: Helm chart for ahnlich-ai, the embedding / AI proxy in front of ahnlich-db.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 home: https://github.com/deven96/ahnlich
 sources:

--- a/charts/ahnlich-db/Chart.yaml
+++ b/charts/ahnlich-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ahnlich-db
 description: Helm chart for ahnlich-db, the in-memory vector database
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 home: https://github.com/deven96/ahnlich
 sources:

--- a/charts/ahnlich/Chart.lock
+++ b/charts/ahnlich/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: ahnlich-db
   repository: file://../ahnlich-db
-  version: 0.1.0
+  version: 0.1.1
 - name: ahnlich-ai
   repository: file://../ahnlich-ai
-  version: 0.1.0
-digest: sha256:9fef0cb0e428b3be662c5d26a80804f8a49ff33f9ff87387ba6eff52a8bb643e
-generated: "2026-05-20T20:37:38.592968+02:00"
+  version: 0.1.1
+digest: sha256:0d286927fcb9aead50f579125f55fcc4e58f2713cea54a3ab6862c3ffa22cbf9
+generated: "2026-07-04T10:51:51.47744+02:00"

--- a/charts/ahnlich/Chart.yaml
+++ b/charts/ahnlich/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ahnlich
 description: Umbrella chart that deploys ahnlich-db and ahnlich-ai together with optional tracing backend.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 home: https://github.com/deven96/ahnlich
 sources:
@@ -14,8 +14,8 @@ keywords:
 
 dependencies:
   - name: ahnlich-db
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../ahnlich-db"
   - name: ahnlich-ai
-    version: "0.1.0"
+    version: "0.1.1"
     repository: "file://../ahnlich-ai"


### PR DESCRIPTION
Bumps `ahnlich-db`, `ahnlich-ai`, and the umbrella `ahnlich` from 0.1.0 to **0.1.1** (umbrella dependency pins + `Chart.lock` updated to match).

**Why:** ArtifactHub only sets the Verified Publisher flag on the next time it *processes* a repo, and an OCI repo is only reprocessed when a **chart version changes**. The `:artifacthub.io` metadata (already pushed, correct, public) has therefore never been re-read. This no-op version bump forces the reprocess so the badge activates on all three repos.

No behaviour change — deps stay `file://` (self-contained umbrella; see PR discussion). On merge, `charts-release.yml` republishes 0.1.1 to `oci://ghcr.io/deven96/charts`.