### PR TITLE
docs: add UPSERT documentation across SDK READMEs and guides

### DIFF
--- a/sdk/ahnlich-client-go/README.md
+++ b/sdk/ahnlich-client-go/README.md
@@ -17,6 +17,7 @@
   - [Get Store](#get-store)
   - [Create Store](#create-store)
   - [Set](#set)
+  - [Upsert](#upsert)
   - [Get Sim N](#get-sim-n)
   - [Get Key](#get-key)
   - [Get By Predicate](#get-by-predicate)
@@ -36,6 +37,7 @@
   - [Get Store](#get-store-1)
   - [Create Store](#create-store-1)
   - [Set](#set-1)
+  - [Upsert](#upsert-1)
   - [Get Sim N](#get-sim-n-1)
   - [Get By Predicate](#get-by-predicate-1)
   - [Create Predicate Index](#create-predicate-index-1)
@@ -246,6 +248,17 @@ func (c *ExampleDBClient) exampleCreateStore() error {
 func (c *ExampleDBClient) exampleSet() error {
     entries := []*keyval.DbStoreEntry{{Key:&keyval.StoreKey{Key:[]float32{1,2,3,4}},Value:&keyval.StoreValue{Value:map[string]*metadata.MetadataValue{"label":{Value:&metadata.MetadataValue_RawString{RawString:"A"}}}}}}
     _, err := c.client.Set(c.ctx, &dbquery.Set{Store:"my_store", Inputs:entries})
+    return err
+}
+```
+
+### Upsert
+```go
+func (c *ExampleDBClient) exampleUpsert() error {
+    cond := &predicates.PredicateCondition{Kind:&predicates.PredicateCondition_Value{Value:&predicates.Predicate{Kind:&predicates.Predicate_Equals{Equals:&predicates.Equals{Key:"id",Value:&metadata.MetadataValue{Value:&metadata.MetadataValue_RawString{RawString:"123"}}}}}}}
+    newValue := &keyval.StoreValue{Value:map[string]*metadata.MetadataValue{"status":{Value:&metadata.MetadataValue_RawString{RawString:"published"}}}}
+    mergeMetadata := true
+    _, err := c.client.Upsert(c.ctx, &dbquery.Upsert{Store:"my_store", Condition:cond, NewValue:newValue, MergeMetadata:&mergeMetadata})
     return err
 }
 ```
@@ -464,6 +477,16 @@ func (c *ExampleAIClient) exampleSetAI(ctx context.Context) error {
         Inputs:           inputs,
         PreprocessAction: preprocess.PreprocessAction_NoPreprocessing,
     })
+    return err
+}
+```
+
+### Upsert
+```go
+func (c *ExampleAIClient) exampleUpsertAI(ctx context.Context) error {
+    cond := &predicates.PredicateCondition{Kind:&predicates.PredicateCondition_Value{Value:&predicates.Predicate{Kind:&predicates.Predicate_Equals{Equals:&predicates.Equals{Key:"filename",Value:&metadata.MetadataValue{Value:&metadata.MetadataValue_RawString{RawString:"photo.jpg"}}}}}}}
+    newValue := &keyval.StoreValue{Value:map[string]*metadata.MetadataValue{"tags":{Value:&metadata.MetadataValue_RawString{RawString:"cat,outdoors"}}}}
+    _, err := c.client.Upsert(c.ctx, &aiquery.Upsert{Store:"images", Condition:cond, NewValue:newValue, PreprocessAction:preprocess.PreprocessAction_NoPreprocessing})
     return err
 }
 ```

--- a/sdk/ahnlich-client-node/README.md
+++ b/sdk/ahnlich-client-node/README.md
@@ -21,6 +21,7 @@ A Node.js/TypeScript client that interacts with both Ahnlich DB and AI over gRPC
   - [Get Store](#get-store)
   - [Create Store](#create-store)
   - [Set](#set)
+  - [Upsert](#upsert)
   - [Get Sim N](#get-sim-n)
   - [Get Key](#get-key)
   - [Get By Predicate](#get-by-predicate)
@@ -38,6 +39,7 @@ A Node.js/TypeScript client that interacts with both Ahnlich DB and AI over gRPC
   - [Get Store](#get-store-1)
   - [Create Store](#create-store-1)
   - [Set](#set-1)
+  - [Upsert](#upsert-1)
   - [Get Sim N](#get-sim-n-1)
   - [Get By Predicate](#get-by-predicate-1)
   - [Create Predicate Index](#create-predicate-index-1)
@@ -200,6 +202,45 @@ await client.set(
         }),
       }),
     ],
+  }),
+);
+```
+
+### Upsert
+
+```ts
+import { Upsert } from "ahnlich-client-node/grpc/db/query_pb";
+import { StoreValue } from "ahnlich-client-node/grpc/keyval_pb";
+import { MetadataValue } from "ahnlich-client-node/grpc/metadata_pb";
+import { PredicateCondition, Predicate, Equals } from "ahnlich-client-node/grpc/predicates_pb";
+
+const condition = new PredicateCondition({
+  kind: {
+    case: "value",
+    value: new Predicate({
+      kind: {
+        case: "equals",
+        value: new Equals({
+          key: "id",
+          value: new MetadataValue({ value: { case: "rawString", value: "123" } }),
+        }),
+      },
+    }),
+  },
+});
+
+const newValue = new StoreValue({
+  value: {
+    status: new MetadataValue({ value: { case: "rawString", value: "published" } }),
+  },
+});
+
+await client.upsert(
+  new Upsert({
+    store: "my_store",
+    condition,
+    newValue,
+    mergeMetadata: true,
   }),
 );
 ```
@@ -445,6 +486,46 @@ await client.set(
         }),
       }),
     ],
+    preprocessAction: PreprocessAction.NO_PREPROCESSING,
+  }),
+);
+```
+
+### Upsert
+
+```ts
+import { Upsert } from "ahnlich-client-node/grpc/ai/query_pb";
+import { StoreValue } from "ahnlich-client-node/grpc/keyval_pb";
+import { MetadataValue } from "ahnlich-client-node/grpc/metadata_pb";
+import { PredicateCondition, Predicate, Equals } from "ahnlich-client-node/grpc/predicates_pb";
+import { PreprocessAction } from "ahnlich-client-node/grpc/ai/preprocess_pb";
+
+const condition = new PredicateCondition({
+  kind: {
+    case: "value",
+    value: new Predicate({
+      kind: {
+        case: "equals",
+        value: new Equals({
+          key: "filename",
+          value: new MetadataValue({ value: { case: "rawString", value: "photo.jpg" } }),
+        }),
+      },
+    }),
+  },
+});
+
+const newValue = new StoreValue({
+  value: {
+    tags: new MetadataValue({ value: { case: "rawString", value: "cat,outdoors" } }),
+  },
+});
+
+await client.upsert(
+  new Upsert({
+    store: "images",
+    condition,
+    newValue,
     preprocessAction: PreprocessAction.NO_PREPROCESSING,
   }),
 );

--- a/sdk/ahnlich-client-py/README.md
+++ b/sdk/ahnlich-client-py/README.md
@@ -23,6 +23,7 @@ The following topics are covered:
     * [List Stores](#list-stores)
     * [Create Store](#create-store)
     * [Set](#set)
+    * [Upsert](#upsert)
     * [Drop Store](#drop-store)
     * [Get Sim N](#get-sim-n)
     * [Get Key](#get-key)
@@ -40,6 +41,7 @@ The following topics are covered:
     * [List Stores](#list-stores-1)
     * [Create Store](#create-store-1)
     * [Set](#set-1)
+    * [Upsert](#upsert-1)
     * [Drop Store](#drop-store-1)
     * [Get Sim N](#get-sim-n-1)
     * [Get By Predicate](#get-by-predicate-1)
@@ -220,6 +222,39 @@ async with Channel(host="127.0.0.1", port=1369) as channel:
     # response contains upsert counts (inserted, updated)
 ```
 
+### Upsert
+```py
+from grpclib.client import Channel
+from ahnlich_client_py.grpc.services.db_service import DbServiceStub
+from ahnlich_client_py.grpc import keyval, metadata, predicates
+from ahnlich_client_py.grpc.db import query as db_query
+
+async with Channel(host="127.0.0.1", port=1369) as channel:
+    client = DbServiceStub(channel)
+    
+    condition = predicates.PredicateCondition(
+        value=predicates.Predicate(
+            equals=predicates.Equals(
+                key="id",
+                value=metadata.MetadataValue(raw_string="123")
+            )
+        )
+    )
+    
+    new_value = keyval.StoreValue(
+        value={"status": metadata.MetadataValue(raw_string="published")}
+    )
+    
+    response = await client.upsert(
+        db_query.Upsert(
+            store="test store",
+            condition=condition,
+            new_value=new_value,
+            merge_metadata=True
+        )
+    )
+    # response.upsert contains (inserted, updated) counts
+```
 
 ### Drop store
 ```py
@@ -574,6 +609,40 @@ async with Channel(host="127.0.0.1", port=1370) as channel:
     )
 ```
 
+### Upsert
+```py
+from grpclib.client import Channel
+from ahnlich_client_py.grpc.services.ai_service import AiServiceStub
+from ahnlich_client_py.grpc.ai import query as ai_query
+from ahnlich_client_py.grpc import keyval, metadata, predicates
+from ahnlich_client_py.grpc.ai import preprocess
+
+async with Channel(host="127.0.0.1", port=1370) as channel:
+    client = AiServiceStub(channel)
+    
+    condition = predicates.PredicateCondition(
+        value=predicates.Predicate(
+            equals=predicates.Equals(
+                key="filename",
+                value=metadata.MetadataValue(raw_string="photo.jpg")
+            )
+        )
+    )
+    
+    new_value = keyval.StoreValue(
+        value={"tags": metadata.MetadataValue(raw_string="cat,outdoors")}
+    )
+    
+    response = await client.upsert(
+        ai_query.Upsert(
+            store="images",
+            condition=condition,
+            new_value=new_value,
+            preprocess_action=preprocess.PreprocessAction.NoPreprocessing
+        )
+    )
+    # response.upsert contains (inserted, updated) counts
+```
 
 ### Drop store
 ```py

--- a/web/ahnlich-web/docs/client-libraries/go/go.md
+++ b/web/ahnlich-web/docs/client-libraries/go/go.md
@@ -109,6 +109,22 @@ Build Ahnlich Applications with the Go SDK – Vector Storage, Search, and AI to
 
 <div className="m-10">
 
+#### [Upsert](/docs/client-libraries/go/request-db/upsert)
+
+    * Description
+
+    * Source Code Example
+
+    * Parameters
+
+    * Returns
+
+    * Behavior
+
+</div>
+
+<div className="m-10">
+
 #### [GetSimN](/docs/client-libraries/go/request-db/get-simn)
 
     * Description
@@ -332,6 +348,21 @@ Build Ahnlich Applications with the Go SDK – Vector Storage, Search, and AI to
 <div className="m-10">
 
 #### [Set](/docs/client-libraries/go/request-ai/set)
+
+- Description
+
+- Source Code Example
+
+- Parameters
+
+- Returns
+
+- Behavior
+</div>
+
+<div className="m-10">
+
+#### [Upsert](/docs/client-libraries/go/request-ai/upsert)
 
 - Description
 

--- a/web/ahnlich-web/docs/client-libraries/node/node.md
+++ b/web/ahnlich-web/docs/client-libraries/node/node.md
@@ -115,6 +115,21 @@ Build Ahnlich Applications with the Node.js/TypeScript SDK - Vector Storage, Sea
 
 <div className="m-10">
 
+  #### [Upsert](/docs/client-libraries/node/request-db/upsert)
+
+    * Description
+
+    * Source Code Example
+
+    * Parameters
+
+    * Returns
+
+    * Behavior
+</div>
+
+<div className="m-10">
+
   #### [GetSimN](/docs/client-libraries/node/request-db/get-simn)
 
     * Description
@@ -358,6 +373,21 @@ Build Ahnlich Applications with the Node.js/TypeScript SDK - Vector Storage, Sea
 <div className="m-10">
 
   #### [Set](/docs/client-libraries/node/request-ai/set)
+
+  * Description
+
+  * Source Code Example
+
+  * Parameters
+
+  * Returns
+
+  * Behavior
+</div>
+
+<div className="m-10">
+
+  #### [Upsert](/docs/client-libraries/node/request-ai/upsert)
 
   * Description
 

--- a/web/ahnlich-web/docs/client-libraries/python/python.md
+++ b/web/ahnlich-web/docs/client-libraries/python/python.md
@@ -102,6 +102,21 @@ Build Ahnlich Applications with the Python SDK – Vector Storage, Search, and A
 
 <div className="m-10">
 
+  #### [Upsert](/docs/client-libraries/python/request-db/upsert)
+
+    * Description
+
+    * Source Code Example
+
+    * Parameters
+
+    * Returns
+
+    * Behavior
+</div>
+
+<div className="m-10">
+
   #### [GetSimN](/docs/client-libraries/python/request-db/get-simn)
 
     * Description
@@ -315,6 +330,21 @@ Build Ahnlich Applications with the Python SDK – Vector Storage, Search, and A
 <div className="m-10">
 
   #### [Set](/docs/client-libraries/python/request-ai/set)
+
+  * Description
+
+  * Source Code Example
+
+  * Parameters
+
+  * Returns
+
+  * Behavior
+</div>
+
+<div className="m-10">
+
+  #### [Upsert](/docs/client-libraries/python/request-ai/upsert)
 
   * Description
 

--- a/web/ahnlich-web/docs/client-libraries/rust/rust.md
+++ b/web/ahnlich-web/docs/client-libraries/rust/rust.md
@@ -115,6 +115,18 @@ Build Ahnlich Applications with the Rust SDK – Vector Storage, Search, and AI 
 
 * Behavior
 
+### [Upsert](/docs/client-libraries/rust/request-db/upsert)
+
+* Description
+
+* Source Code Example
+
+* Parameters
+
+* Returns
+
+* Behavior
+
 ### [Get Sim N](/docs/client-libraries/rust/request-db/get-simn)
 
 * Description
@@ -297,6 +309,18 @@ Build Ahnlich Applications with the Rust SDK – Vector Storage, Search, and AI 
 * Behavior
 
 ### [Set](/docs/client-libraries/rust/request-ai/set)
+
+* Description
+
+* Source Code Example
+
+* Parameters
+
+* Returns
+
+* Behavior
+
+### [Upsert](/docs/client-libraries/rust/request-ai/upsert)
 
 * Description
 

--- a/web/ahnlich-web/docs/getting-started/quickstart.mdx
+++ b/web/ahnlich-web/docs/getting-started/quickstart.mdx
@@ -372,7 +372,145 @@ SET (([A galactic empire in decline...], {genre: SciFi, author: Asimov})) IN boo
 </TabItem>
 </Tabs>
 
-## 4. Search
+## 4. Update data
+
+UPSERT finds a single matching entry using a predicate condition and updates its raw input or metadata.
+
+<Tabs groupId="ahnlich-lang" queryString>
+<TabItem value="python" label="Python" default>
+
+```python title="upsert.py"
+from ahnlich_client_py.grpc import ai_query, keyval, metadata, predicates
+from ahnlich_client_py.grpc.ai import preprocess
+
+# Update the book with genre "SciFi" - change its author metadata
+await client.upsert(ai_query.Upsert(
+    store="books",
+    # New text to embed (replaces the old key)
+    new_input=keyval.StoreInput(raw_string="The Foundation trilogy explores psychohistory"),
+    # New metadata (merges with existing by default in AI)
+    new_value=keyval.StoreValue(value={
+        "author": metadata.MetadataValue(raw_string="Isaac Asimov"),
+    }),
+    # Find the entry to update using a predicate
+    condition=predicates.PredicateCondition(predicates=[
+        predicates.Predicate(key="genre", value=metadata.MetadataValue(raw_string="SciFi"))
+    ]),
+    preprocess_action=preprocess.PreprocessAction.ModelPreprocessing,
+))
+```
+
+</TabItem>
+<TabItem value="rust" label="Rust">
+
+```rust title="upsert.rs"
+use ahnlich_types::ai::query::Upsert;
+use ahnlich_types::ai::preprocess::PreprocessAction;
+use ahnlich_types::keyval::{StoreInput, StoreValue};
+use ahnlich_types::keyval::store_input::Value;
+use ahnlich_types::metadata::{MetadataValue, metadata_value::Value as MValue};
+use ahnlich_types::predicate::{Predicate, PredicateCondition};
+use std::collections::HashMap;
+
+let mut new_metadata = HashMap::new();
+new_metadata.insert("author".to_string(),
+    MetadataValue { value: Some(MValue::RawString("Isaac Asimov".into())) });
+
+client.upsert(Upsert {
+    store: "books".to_string(),
+    schema: None,
+    execution_provider: None,
+    // New text to embed
+    new_input: Some(StoreInput { value: Some(Value::RawString("The Foundation trilogy explores psychohistory".into())) }),
+    // New metadata (merges automatically in AI)
+    new_value: Some(StoreValue { value: new_metadata }),
+    // Predicate to find entry
+    condition: Some(PredicateCondition {
+        predicates: vec![Predicate {
+            key: "genre".to_string(),
+            value: Some(MetadataValue { value: Some(MValue::RawString("SciFi".into())) }),
+        }],
+    }),
+    preprocess_action: PreprocessAction::ModelPreprocessing as i32,
+    model_params: HashMap::new(),
+}, None).await?;
+```
+
+</TabItem>
+<TabItem value="node" label="Node">
+
+```typescript title="upsert.ts"
+import { Upsert } from "ahnlich-client-node/grpc/ai/query_pb";
+import { StoreInput, StoreValue } from "ahnlich-client-node/grpc/keyval_pb";
+import { MetadataValue } from "ahnlich-client-node/grpc/metadata_pb";
+import { PreprocessAction } from "ahnlich-client-node/grpc/ai/preprocess_pb";
+import { Predicate, PredicateCondition } from "ahnlich-client-node/grpc/predicate_pb";
+
+await client.upsert(
+  new Upsert({
+    store: "books",
+    // New text to embed
+    newInput: new StoreInput({ value: { case: "rawString", value: "The Foundation trilogy explores psychohistory" } }),
+    // New metadata (merges automatically in AI)
+    newValue: new StoreValue({
+      value: {
+        author: new MetadataValue({ value: { case: "rawString", value: "Isaac Asimov" } }),
+      },
+    }),
+    // Find entry by predicate
+    condition: new PredicateCondition({
+      predicates: [
+        new Predicate({
+          key: "genre",
+          value: new MetadataValue({ value: { case: "rawString", value: "SciFi" } }),
+        }),
+      ],
+    }),
+    preprocessAction: PreprocessAction.MODEL_PREPROCESSING,
+  })
+);
+```
+
+</TabItem>
+<TabItem value="go" label="Go">
+
+```go title="upsert.go"
+import (
+    keyval "github.com/deven96/ahnlich/sdk/ahnlich-client-go/grpc/keyval"
+    metadata "github.com/deven96/ahnlich/sdk/ahnlich-client-go/grpc/metadata"
+    predicates "github.com/deven96/ahnlich/sdk/ahnlich-client-go/grpc/predicate"
+    preprocess "github.com/deven96/ahnlich/sdk/ahnlich-client-go/grpc/ai/preprocess"
+)
+
+_, err = client.Upsert(ctx, &aiquery.Upsert{
+    Store: "books",
+    // New text to embed
+    NewInput: &keyval.StoreInput{Value: &keyval.StoreInput_RawString{
+        RawString: "The Foundation trilogy explores psychohistory"}},
+    // New metadata (merges automatically in AI)
+    NewValue: &keyval.StoreValue{Value: map[string]*metadata.MetadataValue{
+        "author": {Value: &metadata.MetadataValue_RawString{RawString: "Isaac Asimov"}},
+    }},
+    // Find entry by predicate
+    Condition: &predicates.PredicateCondition{Predicates: []*predicates.Predicate{{
+        Key:   "genre",
+        Value: &metadata.MetadataValue{Value: &metadata.MetadataValue_RawString{RawString: "SciFi"}},
+    }}},
+    PreprocessAction: preprocess.PreprocessAction_ModelPreprocessing,
+})
+```
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+```bash
+UPSERT NEWINPUT [The Foundation trilogy explores psychohistory] NEWVALUE {author: Isaac Asimov} WHERE (genre = SciFi) IN books
+```
+
+</TabItem>
+</Tabs>
+
+## 5. Search
 
 Query by meaning, with results ranked by similarity.
 
@@ -482,7 +620,7 @@ GETSIMN 3 WITH [space opera classics] USING cosinesimilarity IN books WHERE (gen
 You now have semantic search working end to end. The sections below cover the
 rest of the everyday operations.
 
-## 5. Filter your search
+## 6. Filter your search
 
 Combine similarity with a metadata condition — only return matches where a
 predicate holds (e.g. `genre = SciFi`).
@@ -617,10 +755,10 @@ GETSIMN 3 WITH [space opera classics] USING cosinesimilarity IN books WHERE (gen
 
 :::tip
 A metadata field must be declared as a **predicate** on the store (or indexed
-with `CREATEPREDINDEX`) before you can filter on it. See step 7.
+with `CREATEPREDINDEX`) before you can filter on it. See step 8.
 :::
 
-## 6. Retrieve by key
+## 7. Retrieve by key
 
 Fetch entries by their original input — handy when you already know the exact
 text. Requires the store to have been created with `store_original = true`.
@@ -691,9 +829,9 @@ GETKEY ([A galactic empire in decline...]) IN books
 </TabItem>
 </Tabs>
 
-## 7. Speed up filters with an index
+## 8. Speed up filters with an index
 
-Create a predicate index so metadata filters (step 5) stay fast as your store
+Create a predicate index so metadata filters (step 6) stay fast as your store
 grows. You can add predicates that weren't declared at creation time.
 
 <Tabs groupId="ahnlich-lang" queryString>
@@ -750,7 +888,7 @@ CREATEPREDINDEX (author, genre) IN books
 </TabItem>
 </Tabs>
 
-## 8. Inspect your stores
+## 9. Inspect your stores
 
 List every store on the server, along with its size, dimensions, and models.
 
@@ -801,7 +939,7 @@ LISTSTORES
 </TabItem>
 </Tabs>
 
-## 9. Clean up
+## 10. Clean up
 
 Delete individual entries with **del key**, or remove the whole store with
 **drop store**.

--- a/web/ahnlich-web/docs/getting-started/usage.md
+++ b/web/ahnlich-web/docs/getting-started/usage.md
@@ -134,6 +134,7 @@ against the stored vectors.
 | `CREATESTORE <name> DIMENSION <n> ...` | Create a vector store |
 | `CREATEPREDINDEX (k1, k2) IN <store>` | Create a predicate (metadata) index |
 | `SET (...) IN <store>` | Insert one or more vectors |
+| `UPSERT NEWKEY [<vector>] NEWVALUE {k:v} WHERE (<predicate>) IN <store>` | Update a single entry matching predicate |
 | `GETKEY (<vector>) IN <store>` | Retrieve entries by exact key |
 | `GETSIMN <n> WITH [<vector>] USING <metric> IN <store> WHERE (<predicate>)` | Query nearest neighbors |
 | `DROPSTORE <name> IF EXISTS` | Delete a store |
@@ -149,6 +150,7 @@ against the stored vectors.
 | `CREATESTORE <name> QUERYMODEL <m> INDEXMODEL <m> ...` | Create an AI store bound to embedding models |
 | `CREATEPREDINDEX (k1, k2) IN <store>` | Create a predicate (metadata) index |
 | `SET (...) IN <store> PREPROCESSACTION <action>` | Insert raw text/images (embedded automatically) |
+| `UPSERT NEWINPUT [<text>] NEWVALUE {k:v} WHERE (<predicate>) IN <store>` | Update a single entry matching predicate |
 | `GETSIMN <n> WITH [<raw input>] USING <metric> IN <store> WHERE (<predicate>)` | Query nearest neighbors by meaning |
 | `DROPSTORE <name> IF EXISTS` | Delete a store |
 


### PR DESCRIPTION
Add UPSERT operation documentation to:
- SDK READMEs (Python, Go, Node) with verified code examples
- Client library pages (Python, Go, Node, Rust)
- CLI reference table in usage.md
- AI quickstart guide with multi-language examples