### PR TITLE
fix: repair db benches (Schema API) + auto-format generated code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,12 @@ jobs:
         make format
         make clippy
 
+    - name: Compile benchmarks (guard against bench rot)
+      # `make clippy` does not build bench targets, so bench-only breakage
+      # (e.g. an engine API change) can merge undetected. Compile-check them.
+      working-directory: ./ahnlich
+      run: cargo build --benches --workspace
+
     - name: Check Rust Client is up to date
       working-directory: ./ahnlich
       run: |

--- a/ahnlich/db/benches/memory_profile.rs
+++ b/ahnlich/db/benches/memory_profile.rs
@@ -62,6 +62,7 @@ fn profile_batch_insertion(size: usize) {
             &StoreName {
                 value: store_name.to_string(),
             },
+            &Schema::default(),
             bulk_insert,
         )
         .unwrap();
@@ -103,6 +104,7 @@ fn profile_similarity_queries(size: usize, num_queries: usize) {
             &StoreName {
                 value: store_name.to_string(),
             },
+            &Schema::default(),
             bulk_insert,
         )
         .unwrap();
@@ -118,6 +120,7 @@ fn profile_similarity_queries(size: usize, num_queries: usize) {
                 &StoreName {
                     value: store_name.to_string(),
                 },
+                &Schema::default(),
                 random_input,
                 NonZeroUsize::new(50).unwrap(),
                 Algorithm::CosineSimilarity,
@@ -184,6 +187,7 @@ fn profile_predicate_queries(size: usize, num_queries: usize, with_index: bool) 
             &StoreName {
                 value: store_name.to_string(),
             },
+            &Schema::default(),
             bulk_insert,
         )
         .unwrap();
@@ -211,6 +215,7 @@ fn profile_predicate_queries(size: usize, num_queries: usize, with_index: bool) 
                 &StoreName {
                     value: store_name.to_string(),
                 },
+                &Schema::default(),
                 &condition,
             )
             .unwrap();

--- a/ahnlich/db/benches/persistence.rs
+++ b/ahnlich/db/benches/persistence.rs
@@ -124,7 +124,7 @@ fn create_test_store_with_data(
         .collect();
 
     handler
-        .set_in_store(&store_name, entries)
+        .set_in_store(&store_name, &Schema::default(), entries)
         .expect("Failed to insert entries");
 
     (handler, store_name)
@@ -210,7 +210,10 @@ fn bench_persistence(c: &mut Criterion) {
                 b.iter(|| {
                     let temp_dir = TempDir::new().unwrap();
                     let file_path = temp_dir.path().join("stores.json");
-                    let stores = handler.get_snapshot();
+                    let stores = handler
+                        .get_snapshot()
+                        .into_latest()
+                        .expect("migrate snapshot");
                     serialize_with_json(&stores, &file_path)
                         .expect("Failed to serialize with JSON");
 
@@ -230,7 +233,10 @@ fn bench_persistence(c: &mut Criterion) {
                 b.iter(|| {
                     let temp_dir = TempDir::new().unwrap();
                     let file_path = temp_dir.path().join("stores.bitcode");
-                    let stores = handler.get_snapshot();
+                    let stores = handler
+                        .get_snapshot()
+                        .into_latest()
+                        .expect("migrate snapshot");
                     serialize_with_bitcode(&stores, &file_path)
                         .expect("Failed to serialize with bitcode");
 
@@ -250,7 +256,10 @@ fn bench_persistence(c: &mut Criterion) {
                 b.iter(|| {
                     let temp_dir = TempDir::new().unwrap();
                     let file_path = temp_dir.path().join("stores.json");
-                    let stores = handler.get_snapshot();
+                    let stores = handler
+                        .get_snapshot()
+                        .into_latest()
+                        .expect("migrate snapshot");
                     serialize_with_json(&stores, &file_path)
                         .expect("Failed to serialize with JSON");
 
@@ -269,7 +278,10 @@ fn bench_persistence(c: &mut Criterion) {
                 b.iter(|| {
                     let temp_dir = TempDir::new().unwrap();
                     let file_path = temp_dir.path().join("stores.bitcode");
-                    let stores = handler.get_snapshot();
+                    let stores = handler
+                        .get_snapshot()
+                        .into_latest()
+                        .expect("migrate snapshot");
                     serialize_with_bitcode(&stores, &file_path)
                         .expect("Failed to serialize with bitcode");
 
@@ -291,7 +303,10 @@ fn bench_persistence(c: &mut Criterion) {
             let (handler, _store_name) = create_test_store_with_data(size, dimension, false, true);
             let temp_dir = TempDir::new().unwrap();
             let file_path = temp_dir.path().join("stores.json");
-            let stores = handler.get_snapshot();
+            let stores = handler
+                .get_snapshot()
+                .into_latest()
+                .expect("migrate snapshot");
             serialize_with_json(&stores, &file_path).expect("Setup failed");
 
             let bench_name = format!("{}_entries_no_index_json", size);
@@ -311,7 +326,10 @@ fn bench_persistence(c: &mut Criterion) {
             let (handler, _store_name) = create_test_store_with_data(size, dimension, false, true);
             let temp_dir = TempDir::new().unwrap();
             let file_path = temp_dir.path().join("stores.bitcode");
-            let stores = handler.get_snapshot();
+            let stores = handler
+                .get_snapshot()
+                .into_latest()
+                .expect("migrate snapshot");
             serialize_with_bitcode(&stores, &file_path).expect("Setup failed");
 
             let bench_name = format!("{}_entries_no_index_bitcode", size);
@@ -330,7 +348,10 @@ fn bench_persistence(c: &mut Criterion) {
             let (handler, _store_name) = create_test_store_with_data(size, dimension, true, true);
             let temp_dir = TempDir::new().unwrap();
             let file_path = temp_dir.path().join("stores.json");
-            let stores = handler.get_snapshot();
+            let stores = handler
+                .get_snapshot()
+                .into_latest()
+                .expect("migrate snapshot");
             serialize_with_json(&stores, &file_path).expect("Setup failed");
 
             let bench_name = format!("{}_entries_hnsw_json", size);
@@ -349,7 +370,10 @@ fn bench_persistence(c: &mut Criterion) {
             let (handler, _store_name) = create_test_store_with_data(size, dimension, true, true);
             let temp_dir = TempDir::new().unwrap();
             let file_path = temp_dir.path().join("stores.bitcode");
-            let stores = handler.get_snapshot();
+            let stores = handler
+                .get_snapshot()
+                .into_latest()
+                .expect("migrate snapshot");
             serialize_with_bitcode(&stores, &file_path).expect("Setup failed");
 
             let bench_name = format!("{}_entries_hnsw_bitcode", size);

--- a/ahnlich/types/build.rs
+++ b/ahnlich/types/build.rs
@@ -25,7 +25,13 @@ fn main() -> Result<()> {
             .to_str()
             .expect("Cannot get proto dir str path")
     );
-    println!("cargo:warning=Run `cargo fmt` after build to format generated files.");
+
+    // Only regenerate when the proto sources are present, i.e. in-repo dev
+    // builds. Downstream consumers building from crates.io have no `protos/`
+    // and must use the committed, pre-generated code unchanged.
+    if !proto_dir.exists() {
+        return Ok(());
+    }
 
     let protofiles: Vec<PathBuf> = WalkDir::new(proto_dir.clone())
         .into_iter()
@@ -119,8 +125,32 @@ fn main() -> Result<()> {
         .expect("failed");
 
     restructure_generated_code(&out_dir, &mut file);
+    format_generated_code(&out_dir);
 
     Ok(())
+}
+
+/// Run rustfmt over the freshly generated files so the output matches
+/// `cargo fmt`, avoiding the "regenerate produces an unformatted diff" churn.
+/// rustfmt not being available is non-fatal (formatting does not affect
+/// compilation).
+fn format_generated_code(out_dir: &PathBuf) {
+    let files: Vec<PathBuf> = WalkDir::new(out_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "rs"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    match std::process::Command::new("rustfmt")
+        .arg("--edition")
+        .arg("2024")
+        .args(&files)
+        .status()
+    {
+        Ok(status) if status.success() => {}
+        Ok(status) => println!("cargo:warning=rustfmt exited with {status} on generated code"),
+        Err(err) => println!("cargo:warning=could not run rustfmt on generated code: {err}"),
+    }
 }
 
 fn restructure_generated_code(out_dir: &PathBuf, file: &mut std::fs::File) {


### PR DESCRIPTION
Repairs the memory_profile/persistence benches broken by the Schema arg (#343), makes `types/build.rs` rustfmt its generated output so plain builds stop emitting a formatting-only diff, and adds a `cargo build --benches` CI step to catch bench rot.