### PR TITLE
fix(hnsw): filter during traversal instead of post-filtering

### DIFF
--- a/ahnlich/similarity/benches/hnsw_bench.rs
+++ b/ahnlich/similarity/benches/hnsw_bench.rs
@@ -161,7 +161,8 @@ fn bench_search_varying_k(c: &mut Criterion) {
     for k in [1, 10, 50] {
         group.bench_with_input(BenchmarkId::new("k", k), &k, |b, &k| {
             b.iter(|| {
-                hnsw.knn_search(black_box(&query), k, Some(100)).unwrap();
+                hnsw.knn_search(black_box(&query), k, Some(100), None)
+                    .unwrap();
             });
         });
     }
@@ -188,7 +189,8 @@ fn bench_search_varying_ef(c: &mut Criterion) {
     for ef in [16, 50, 100, 200] {
         group.bench_with_input(BenchmarkId::new("ef", ef), &ef, |b, &ef| {
             b.iter(|| {
-                hnsw.knn_search(black_box(&query), 10, Some(ef)).unwrap();
+                hnsw.knn_search(black_box(&query), 10, Some(ef), None)
+                    .unwrap();
             });
         });
     }
@@ -210,7 +212,8 @@ fn bench_search_batch_queries(c: &mut Criterion) {
     c.bench_function("search/batch_100_queries_k10_ef100", |b| {
         b.iter(|| {
             for query in &queries {
-                hnsw.knn_search(black_box(query), 10, Some(100)).unwrap();
+                hnsw.knn_search(black_box(query), 10, Some(100), None)
+                    .unwrap();
             }
         });
     });
@@ -246,7 +249,7 @@ fn bench_concurrent_search(c: &mut Criterion) {
                             let hnsw = Arc::clone(&hnsw);
                             let query = queries[t % queries.len()].clone();
                             thread::spawn(move || {
-                                hnsw.knn_search(&query, 10, Some(100)).unwrap();
+                                hnsw.knn_search(&query, 10, Some(100), None).unwrap();
                             })
                         })
                         .collect();

--- a/ahnlich/similarity/src/hnsw/index.rs
+++ b/ahnlich/similarity/src/hnsw/index.rs
@@ -22,6 +22,11 @@ use std::{
     sync::atomic::{AtomicU8, Ordering},
 };
 
+/// Below this many accepted vectors, a filtered search scans the accepted set directly
+/// instead of traversing the graph. At this size an exact SIMD scan costs less than a
+/// graph walk that cannot fill `ef` and therefore keeps widening.
+const BRUTE_FORCE_ACCEPT_LIST_THRESHOLD: usize = 4096;
+
 /// Wrapper around papaya `HashMap::new()` that forces immediate allocation
 /// inside `catch_unwind` to surface initialization panics at construction time
 /// rather than on the first insert.
@@ -224,15 +229,21 @@ impl<D: DistanceFn> HNSW<D> {
             return Ok(vec![]);
         }
 
-        // When accept_list is provided, search for more candidates to account for filtering
-        let search_k = match accept_list {
-            Some(ref list) => n.get().max(list.len()),
-            None => n.get(),
-        };
+        // Highly selective predicate: scanning the matched vectors directly is both cheaper
+        // and exact. Graph traversal degenerates here — with few acceptable nodes the search
+        // cannot fill `ef` and keeps widening, approaching a full traversal for a handful of
+        // results. Below the threshold a linear scan is strictly the better plan.
+        if let Some(ref accept) = accept_list
+            && accept.len() <= BRUTE_FORCE_ACCEPT_LIST_THRESHOLD
+        {
+            return Ok(self.brute_force_accept_list(reference_point, n, accept));
+        }
 
         let query = Node::new(EmbeddingKey::new(reference_point.to_vec()));
-        // knn_search returns results in ascending distance order
-        let result_ids = self.knn_search(&query, search_k, None)?;
+        // `k` is what the caller asked for. It is NOT derived from the size of the filter:
+        // the filter is applied during traversal (see search_layer), so no over-search is
+        // needed to compensate for post-filtering.
+        let result_ids = self.knn_search(&query, n.get(), None, accept_list.as_ref())?;
 
         let nodes_guard = self.nodes.pin();
         let mut results: Vec<(EmbeddingKey, f32)> = Vec::with_capacity(n.get());
@@ -242,13 +253,6 @@ impl<D: DistanceFn> HNSW<D> {
             }
             if let Some(node) = nodes_guard.get(&node_id) {
                 let key = node.value.clone();
-                // Filter by accept_list if provided
-                if let Some(ref accept) = accept_list
-                    && !accept.contains(&node_id.0)
-                {
-                    continue;
-                }
-
                 let distance = self
                     .distance_algorithm
                     .distance(reference_point, key.as_slice());
@@ -257,6 +261,37 @@ impl<D: DistanceFn> HNSW<D> {
         }
 
         Ok(results)
+    }
+
+    /// Exact nearest-neighbour scan restricted to `accept`, used when the predicate is
+    /// selective enough that touching the graph is not worth it.
+    fn brute_force_accept_list(
+        &self,
+        reference_point: &[f32],
+        n: NonZeroUsize,
+        accept: &std::collections::HashSet<u64>,
+    ) -> Vec<(EmbeddingKey, f32)> {
+        let nodes_guard = self.nodes.pin();
+        let mut scored: Vec<(NodeId, EmbeddingKey, f32)> = accept
+            .iter()
+            .filter_map(|id| nodes_guard.get(&NodeId(*id)))
+            .map(|node| {
+                let key = node.value.clone();
+                let distance = self
+                    .distance_algorithm
+                    .distance(reference_point, key.as_slice());
+                (node.id, key, distance)
+            })
+            .collect();
+
+        // Ties break on NodeId, not on HashSet iteration order, so replicas agree.
+        // NodeId is a content hash, so this ordering is stable across processes and restarts.
+        scored.sort_by(|(id_a, _, a), (id_b, _, b)| a.total_cmp(b).then(id_a.0.cmp(&id_b.0)));
+        scored.truncate(n.get());
+        scored
+            .into_iter()
+            .map(|(_, key, distance)| (key, distance))
+            .collect()
     }
 
     /// Insert a new element into the HNSW graph
@@ -288,6 +323,7 @@ impl<D: DistanceFn> HNSW<D> {
                 &enter_point,
                 inital_ef,
                 &LayerIndex(level_current as u16),
+                None,
             )?;
 
             // NOTE: get the nearest element from W to q
@@ -312,8 +348,13 @@ impl<D: DistanceFn> HNSW<D> {
             let layer_index = LayerIndex(level_current as u16);
 
             // NOTE: W = search-layer(q, ep, efConstruction, lc)
-            let nearest_neighbours =
-                self.search_layer(&value, &enter_point, self.ef_construction, &layer_index)?;
+            let nearest_neighbours = self.search_layer(
+                &value,
+                &enter_point,
+                self.ef_construction,
+                &layer_index,
+                None,
+            )?;
 
             // Select M neighbors for the new node at this layer
             // (Algorithm 1: neighbors = SELECT-NEIGHBORS(q, W, M, lc))
@@ -429,15 +470,24 @@ impl<D: DistanceFn> HNSW<D> {
 
     /// Search for ef nearest neighbours in a specific layer
     /// Corresponds to Algorithm 2 (SEARCH-LAYER)
+    ///
+    /// `accept_list`, when supplied, restricts which nodes may enter the result set `W`.
+    /// Rejected nodes are still traversed *through* (they stay in the candidate set `C`),
+    /// because the graph's navigability depends on them as stepping stones — dropping them
+    /// from `C` would disconnect the search. This is "in-filtering": the paper's Algorithm 2
+    /// is unchanged except for which nodes are admitted to `W`.
     pub fn search_layer(
         &self,
         query: &Node,
         entry_points: &[NodeId],
         ef: usize,
         layer: &LayerIndex,
+        accept_list: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<NodeId>, Error> {
         let nodes = self.nodes.pin();
         let mut visited_items: NodeIdHashSet = entry_points.iter().copied().collect();
+
+        let is_accepted = |id: &NodeId| accept_list.is_none_or(|accept| accept.contains(&id.0));
 
         // C - candidates (min heap via Reverse: smallest distance pops first)
         let mut candidates = MinHeapQueue::from_nodes(
@@ -450,6 +500,10 @@ impl<D: DistanceFn> HNSW<D> {
         let ef_nonzero = NonZeroUsize::new(ef).unwrap_or(NonZeroUsize::new(1).unwrap());
         let mut nearest_neighbours: BoundedMinHeap<OrderedNode> = BoundedMinHeap::new(ef_nonzero);
         for node in entry_points.iter().filter_map(|id| nodes.get(id)) {
+            // Entry points navigate regardless, but only enter W if they satisfy the filter.
+            if !is_accepted(&node.id) {
+                continue;
+            }
             let distance = self
                 .distance_algorithm
                 .distance(node.value.as_slice(), query.value.as_slice());
@@ -460,8 +514,13 @@ impl<D: DistanceFn> HNSW<D> {
             let OrderedNode((nearest_id, nearest_dist)) =
                 candidates.pop().ok_or(Error::QueueEmpty)?;
 
-            // Check stopping condition: if candidate is further than worst in nearest_neighbours
-            if let Some(OrderedNode((_, furthest_dist))) = nearest_neighbours.peek()
+            // Stop only once W is FULL and the next candidate is worse than W's furthest.
+            // The `len() >= ef` guard matters: W holds only accepted nodes, so under a
+            // filter it fills slowly. Breaking while W is still under-full would abandon
+            // the search early and return fewer than `ef` results — the unfiltered path
+            // never noticed because W fills immediately when everything is accepted.
+            if nearest_neighbours.len() >= ef
+                && let Some(OrderedNode((_, furthest_dist))) = nearest_neighbours.peek()
                 && nearest_dist > *furthest_dist
             {
                 break;
@@ -488,17 +547,25 @@ impl<D: DistanceFn> HNSW<D> {
                         .distance_algorithm
                         .distance(neighbour_node.value.as_slice(), query.value.as_slice());
 
-                    // Add if better than worst in nearest_neighbours OR if we haven't filled ef yet
-                    let should_add =
+                    // Explore if better than worst in W, OR if we haven't filled ef yet.
+                    // Note W only ever holds accepted nodes, so when a filter is active and
+                    // few nodes are accepted, W stays under ef and the search keeps widening
+                    // until it has found ef acceptable nodes or exhausted the candidates.
+                    let should_explore =
                         if let Some(OrderedNode((_, worst_dist))) = nearest_neighbours.peek() {
                             neighbour_dist < *worst_dist || nearest_neighbours.len() < ef
                         } else {
                             true
                         };
 
-                    if should_add {
+                    if should_explore {
+                        // Always traverse through the node...
                         candidates.push(neighbour_node);
-                        nearest_neighbours.push(OrderedNode((neighbour_node.id, neighbour_dist)));
+                        // ...but only return it if it satisfies the filter.
+                        if is_accepted(neighbour_id) {
+                            nearest_neighbours
+                                .push(OrderedNode((neighbour_node.id, neighbour_dist)));
+                        }
                     }
                 }
             }
@@ -638,6 +705,7 @@ impl<D: DistanceFn> HNSW<D> {
         query: &Node,
         k: usize,
         ef: Option<usize>,
+        accept_list: Option<&std::collections::HashSet<u64>>,
     ) -> Result<Vec<NodeId>, Error> {
         let nodes = self.nodes.pin();
         let valid_len = NonZeroUsize::new(k).expect("K should be a non zero number");
@@ -656,7 +724,9 @@ impl<D: DistanceFn> HNSW<D> {
         for level_current in (1..=ep_level).rev() {
             let layer = LayerIndex(level_current as u16);
 
-            let searched = self.search_layer(query, &enter_point, 1, &layer)?;
+            // Upper layers are navigation only (ef=1 greedy descent). Filtering here would
+            // strand the descent on a non-matching entry point, so it stays unfiltered.
+            let searched = self.search_layer(query, &enter_point, 1, &layer, None)?;
 
             let ep = MinHeapQueue::from_nodes(
                 searched.iter().filter_map(|id| nodes.get(id)),
@@ -669,7 +739,8 @@ impl<D: DistanceFn> HNSW<D> {
             enter_point = smallvec![ep];
         }
 
-        let level_zero = self.search_layer(query, &enter_point, ef, &LayerIndex(0))?;
+        // Layer 0 is where results are collected, so this is the only layer that filters.
+        let level_zero = self.search_layer(query, &enter_point, ef, &LayerIndex(0), accept_list)?;
         let mut current_nearest_elements = MinHeapQueue::from_nodes(
             level_zero.iter().filter_map(|id| nodes.get(id)),
             query,
@@ -1107,7 +1178,7 @@ mod tests {
             back_links: HashSet::new(),
         };
 
-        let res = hnsw.knn_search(&query_node, 1, Some(10)).unwrap();
+        let res = hnsw.knn_search(&query_node, 1, Some(10), None).unwrap();
         assert_eq!(res[0], a);
     }
 

--- a/ahnlich/similarity/src/tests/filtered_perf.rs
+++ b/ahnlich/similarity/src/tests/filtered_perf.rs
@@ -1,0 +1,54 @@
+use crate::EmbeddingKey;
+use crate::hnsw::index::HNSW;
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::time::Instant;
+
+/// Loose predicate: half the store matches. Asking for 10 results should be cheap —
+/// almost anything near the query satisfies the predicate.
+///
+/// Run with:
+///   cargo test -p ahnlich_similarity --release --lib filtered_perf -- --nocapture --ignored
+#[test]
+#[ignore]
+fn perf_loose_filter() {
+    const N: usize = 20_000;
+    const DIM: usize = 128;
+
+    let hnsw = HNSW::default();
+    let keys: Vec<EmbeddingKey> = (0..N)
+        .map(|i| {
+            let base = i as f32 * 0.0001;
+            EmbeddingKey::new((0..DIM).map(|d| base + d as f32 * 0.01).collect())
+        })
+        .collect();
+    hnsw.insert(&keys).expect("insert");
+
+    // accept half the store -> a loose, weakly selective predicate
+    let accept: HashSet<u64> = keys
+        .iter()
+        .step_by(2)
+        .map(|k| ahnlich_types::utils::hash_f32_vec(&k.0))
+        .collect();
+
+    let query: Vec<f32> = (0..DIM).map(|d| d as f32 * 0.01).collect();
+    let n = NonZeroUsize::new(10).unwrap();
+
+    // warm
+    let _ = hnsw.n_nearest(&query, n, Some(accept.clone())).unwrap();
+
+    let start = Instant::now();
+    let iters = 20;
+    for _ in 0..iters {
+        let res = hnsw.n_nearest(&query, n, Some(accept.clone())).unwrap();
+        assert_eq!(res.len(), 10, "loose filter must still return 10 results");
+    }
+    let elapsed = start.elapsed() / iters;
+
+    println!(
+        "LOOSE FILTER (accept {} of {}): {:?} per query",
+        accept.len(),
+        N,
+        elapsed
+    );
+}

--- a/ahnlich/similarity/src/tests/filtered_search.rs
+++ b/ahnlich/similarity/src/tests/filtered_search.rs
@@ -1,0 +1,71 @@
+use crate::EmbeddingKey;
+use crate::hnsw::index::HNSW;
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+
+const DIM: usize = 8;
+const NEAR_COUNT: usize = 900;
+const FAR_COUNT: usize = 100;
+
+/// Build a store with two well-separated clusters:
+/// - NEAR: 900 vectors clustered tightly around the origin
+/// - FAR:  100 vectors clustered far away (around 100.0)
+///
+/// The query is the origin, so every NEAR vector beats every FAR vector.
+fn two_cluster_dataset() -> (Vec<EmbeddingKey>, Vec<EmbeddingKey>) {
+    let near = (0..NEAR_COUNT)
+        .map(|i| EmbeddingKey::new(vec![i as f32 * 0.001; DIM]))
+        .collect();
+    let far = (0..FAR_COUNT)
+        .map(|i| EmbeddingKey::new(vec![100.0 + i as f32 * 0.001; DIM]))
+        .collect();
+    (near, far)
+}
+
+/// A predicate that matches ONLY the far cluster.
+///
+/// There are 100 acceptable vectors and we ask for 10, so a correct filtered
+/// search MUST return 10 results: the 10 nearest members of the far cluster.
+///
+/// The current implementation sets `search_k = max(n, accept_list.len())` = 100,
+/// which drives `ef` = 100, so it retrieves the global top-100 (all of which are
+/// NEAR vectors), then post-filters them against the accept list and finds
+/// nothing acceptable -> returns 0 results.
+#[test]
+fn filtered_search_returns_n_results_when_enough_candidates_match() {
+    let hnsw = HNSW::default();
+    let (near, far) = two_cluster_dataset();
+
+    hnsw.insert(&near).expect("insert near cluster");
+    hnsw.insert(&far).expect("insert far cluster");
+
+    // accept list = the far cluster only
+    let accept_list: HashSet<u64> = far
+        .iter()
+        .map(|k| ahnlich_types::utils::hash_f32_vec(&k.0))
+        .collect();
+
+    let query = vec![0.0f32; DIM];
+    let n = NonZeroUsize::new(10).unwrap();
+
+    let results = hnsw
+        .n_nearest(&query, n, Some(accept_list.clone()))
+        .expect("filtered search should succeed");
+
+    assert_eq!(
+        results.len(),
+        10,
+        "expected 10 results (100 vectors match the predicate), got {}. \
+         Filtered search is dropping results that satisfy the predicate.",
+        results.len()
+    );
+
+    // every returned vector must be in the accept list
+    for (key, _) in &results {
+        let id = ahnlich_types::utils::hash_f32_vec(&key.0);
+        assert!(
+            accept_list.contains(&id),
+            "returned a vector that does not satisfy the predicate"
+        );
+    }
+}

--- a/ahnlich/similarity/src/tests/filtered_search.rs
+++ b/ahnlich/similarity/src/tests/filtered_search.rs
@@ -69,3 +69,76 @@ fn filtered_search_returns_n_results_when_enough_candidates_match() {
         );
     }
 }
+
+/// Force the GRAPH in-filtering path, not the brute-force one.
+///
+/// With more than `BRUTE_FORCE_ACCEPT_LIST_THRESHOLD` (4096) accepted vectors, the search
+/// walks the graph and filters during traversal. This is the subtle path: results must
+/// still be the nearest ACCEPTED vectors, the count must be right, and the excluded nearest
+/// must never appear.
+#[test]
+fn filtered_search_on_the_graph_path_returns_nearest_accepted() {
+    const N: usize = 8_000; // > 4096 so the accept list clears the brute-force threshold
+    const EXCLUDE_NEAREST: usize = 200;
+
+    let hnsw = HNSW::default();
+    // Vectors on a ray from the origin: distance grows with index, so the true ranking is
+    // just the index order.
+    let keys: Vec<EmbeddingKey> = (0..N)
+        .map(|i| EmbeddingKey::new(vec![i as f32 * 0.01; DIM]))
+        .collect();
+    hnsw.insert(&keys).expect("insert");
+
+    // Accept everything except the 200 nearest, so the filter actually changes the answer
+    // and the accepted set (7800) is far above the brute-force threshold.
+    let accept_list: HashSet<u64> = keys
+        .iter()
+        .skip(EXCLUDE_NEAREST)
+        .map(|k| ahnlich_types::utils::hash_f32_vec(&k.0))
+        .collect();
+    assert!(accept_list.len() > 4096, "must exercise the graph path");
+
+    let excluded: HashSet<u64> = keys
+        .iter()
+        .take(EXCLUDE_NEAREST)
+        .map(|k| ahnlich_types::utils::hash_f32_vec(&k.0))
+        .collect();
+
+    let query = vec![0.0f32; DIM];
+    let n = NonZeroUsize::new(10).unwrap();
+    let results = hnsw
+        .n_nearest(&query, n, Some(accept_list.clone()))
+        .unwrap();
+
+    assert_eq!(
+        results.len(),
+        10,
+        "graph path must still return the full count"
+    );
+
+    for (key, _) in &results {
+        let id = ahnlich_types::utils::hash_f32_vec(&key.0);
+        assert!(accept_list.contains(&id), "returned a non-accepted vector");
+        assert!(
+            !excluded.contains(&id),
+            "returned one of the excluded nearest"
+        );
+    }
+
+    // The true nearest accepted are indices EXCLUDE_NEAREST..EXCLUDE_NEAREST+10. HNSW is
+    // approximate, so require high recall rather than an exact match.
+    let truth: HashSet<u64> = keys
+        .iter()
+        .skip(EXCLUDE_NEAREST)
+        .take(10)
+        .map(|k| ahnlich_types::utils::hash_f32_vec(&k.0))
+        .collect();
+    let hits = results
+        .iter()
+        .filter(|(key, _)| truth.contains(&ahnlich_types::utils::hash_f32_vec(&key.0)))
+        .count();
+    assert!(
+        hits >= 8,
+        "expected high recall of the nearest accepted, got {hits}/10"
+    );
+}

--- a/ahnlich/similarity/src/tests/mocked_json_tests.rs
+++ b/ahnlich/similarity/src/tests/mocked_json_tests.rs
@@ -92,7 +92,7 @@ fn test_hnsw_simple_setup_works() {
 
     let query_node = Node::new(query_vec);
     let search_results = hnsw
-        .knn_search(&query_node, 1, None)
+        .knn_search(&query_node, 1, None, None)
         .expect("Failed to search hnsw");
 
     assert_eq!(search_results.len(), 1);
@@ -105,7 +105,7 @@ fn test_hnsw_simple_setup_works() {
     assert_eq!(first, most_similar.id());
 
     let search_results = hnsw
-        .knn_search(&query_node, MOST_SIMILAR.len(), None)
+        .knn_search(&query_node, MOST_SIMILAR.len(), None, None)
         .expect("Failed to search hnsw");
 
     assert_eq!(search_results.len(), MOST_SIMILAR.len());
@@ -132,7 +132,7 @@ fn test_hnsw_recall_on_simple_setup() {
     hnsw.insert(&embeddings).expect("Failed to batch insert");
 
     let hnsw_search_results = hnsw
-        .knn_search(&query_node, MOST_SIMILAR.len(), None)
+        .knn_search(&query_node, MOST_SIMILAR.len(), None, None)
         .expect("Failed to search hnsw");
 
     let overlap = brute_search_results
@@ -163,7 +163,7 @@ fn test_hnsw_average_recall_controlled() {
 
         // HNSW approximate neighbors
         let ann_ids: Vec<_> = hnsw
-            .knn_search(&query_node, k, None)
+            .knn_search(&query_node, k, None, None)
             .expect("HNSW search failed");
 
         // Calculate recall
@@ -224,7 +224,7 @@ fn test_recall_vs_ef_values() {
 
             let brute = brute_knn(&query_node, &nodes, k);
             let ann_ids: Vec<_> = hnsw
-                .knn_search(&query_node, k, Some(ef))
+                .knn_search(&query_node, k, Some(ef), None)
                 .expect("HNSW search failed");
 
             let overlap: usize = brute.iter().filter(|(id, _)| ann_ids.contains(id)).count();
@@ -304,7 +304,7 @@ fn test_recall_vs_ef_on_realistic_dataset() {
 
             // HNSW search
             let ann_ids: Vec<_> = hnsw
-                .knn_search(query_node, k, Some(ef))
+                .knn_search(query_node, k, Some(ef), None)
                 .expect("HNSW search failed");
 
             // Calculate recall
@@ -362,7 +362,7 @@ fn test_recall_vs_ef_on_large_dataset() {
 
             let brute = brute_knn(query_node, &nodes, k);
             let ann_ids: Vec<_> = hnsw
-                .knn_search(query_node, k, Some(ef))
+                .knn_search(query_node, k, Some(ef), None)
                 .expect("HNSW search failed");
 
             let overlap: usize = brute.iter().filter(|(id, _)| ann_ids.contains(id)).count();

--- a/ahnlich/similarity/src/tests/mod.rs
+++ b/ahnlich/similarity/src/tests/mod.rs
@@ -1,3 +1,5 @@
+mod filtered_perf;
+mod filtered_search;
 mod fixtures;
 mod mocked_json_tests;
 mod sift_dataset_validation;

--- a/ahnlich/similarity/src/tests/sift_dataset_validation.rs
+++ b/ahnlich/similarity/src/tests/sift_dataset_validation.rs
@@ -42,7 +42,7 @@ fn compute_recall_for_config(dataset: &AnnDataset, config: HNSWConfig, k: usize)
     for (query_idx, query_vec) in dataset.sift_query.iter().enumerate() {
         let query_node = Node::new(EmbeddingKey::new(query_vec.clone()));
 
-        let ann_ids = hnsw.knn_search(&query_node, K, Some(16)).unwrap();
+        let ann_ids = hnsw.knn_search(&query_node, K, Some(16), None).unwrap();
 
         let true_neighbors = &dataset.ground_truth[query_idx];
 

--- a/docs/specs/hnsw.md
+++ b/docs/specs/hnsw.md
@@ -44,6 +44,10 @@
 
     * [Breakdown](#breakdown-5)
 
+  * [Algorithm 7 — Filtered Search](#algorithm-7)
+
+    * [Breakdown](#breakdown-6)
+
 * [Data Model & API Interface](#data-model--api-interfaces)
 
 * [Needs Further Research / Open Questions](#needs-further-research--open-questions)
@@ -53,7 +57,8 @@
     * [Correctness Testing (Core Validation)](#1-correctness-testing-core-validation)
         * [Linear Scan Baseline (Required, V1)](#11-linear-scan-baseline-required-v1)
         * [FAISS HNSW Comparison (Required, Optional Output Check)](#12-faiss-hnsw-comparison-required-optional-output-check)
-        * [Optional / Advanced Correctness Checks](#13-optional--advanced-correctness-checks)
+        * [Filtered Recall (Required for alg. 7)](#13-filtered-recall-required-for-alg-7)
+        * [Optional / Advanced Correctness Checks](#14-optional--advanced-correctness-checks)
     * [Determinism in a Replicated System](#2-determinism-in-a-replicated-system)
     * [Performance Testing](#3-performance-testing)
         * [Speed Benchmarks](#31-speed-benchmarks)
@@ -569,6 +574,154 @@ To support efficient back-link-based deletions, the **INSERT** procedure would i
 ---
 
 
+### Algorithm 7
+
+> **This algorithm is ours, not the paper's.** The paper does not cover filtered/predicate-constrained
+> search at all — algs. 1-6 assume every node in the graph is a valid answer. We need it because a
+> `GETSIMN` can arrive with a predicate condition attached, so only the subset of nodes matching that
+> predicate may be returned. Everything below is an extension on top of alg. 5 and alg. 2.
+
+The input is an `acceptList`: the set of NodeIds whose vectors satisfy the predicate. It is computed by
+the predicate indices *before* we ever touch the graph, so by this point the filter is just a set membership test.
+
+```
+FILTERED-SEARCH(hnsw, q, K, ef, acceptList)
+Input: multilayer graph hnsw, query element q, number of nearest neighbors to
+return K, size of the dynamic candidate list ef, set of allowed NodeIds acceptList
+Output: K nearest elements to q that are members of acceptList
+
+1 if acceptList = ∅
+2   return ∅                          // predicate matched nothing, no work to do
+3 if │acceptList│ ≤ bruteForceThreshold
+4   return K nearest elements to q from acceptList   // exact scan, skip the graph entirely
+5 return K-NN-SEARCH-FILTERED(hnsw, q, K, ef, acceptList)   // alg. 5, with alg. 2 filtered
+```
+
+`K-NN-SEARCH-FILTERED` is **alg. 5 unchanged**, except that the layer-0 call passes `acceptList` down
+into SEARCH-LAYER. The upper layers (lc ← L … 1) are called with **no** acceptList.
+
+`SEARCH-LAYER` is **alg. 2 unchanged**, except for two lines:
+
+```
+SEARCH-LAYER-FILTERED(q, ep, ef, lc, acceptList)
+  ... identical to alg. 2 ...
+7   if distance(c, q) > distance(f, q) and │W│ = ef      // <- CHANGED: the │W│ = ef guard
+8     break
+  ...
+13  if distance(e, q) < distance(f, q) or │W│ < ef
+14    C ← C ⋃ e                                          // e always joins the candidates
+15    if e ∈ acceptList                                  // <- CHANGED: but only joins W if allowed
+16      W ← W ⋃ e
+17      if │W│ > ef
+18        remove furthest element from W to q
+19 return W
+```
+
+### Breakdown
+
+1. **Empty acceptList** → return immediately. The predicate matched nothing, so no vector can be an answer.
+
+2. **Small acceptList (line 3)**: if the predicate is selective enough, we do not touch the graph at all.
+We just compute the distance from `q` to each of the accepted vectors and take the K nearest. This is
+**exact**, not approximate, and at this size it is cheaper than a graph walk. See Q3 for why the graph walk
+is *especially* bad in exactly this case.
+
+3. **Otherwise (line 5)**: run alg. 5 as normal, and filter inside alg. 2. This is the important part.
+
+4. **Line 14 — `e` always joins `C`.** A node that fails the predicate is still a legitimate *stepping stone*.
+The graph's navigability does not know or care about our predicate; the small-world property lives in the
+edges. If we refused to traverse *through* rejected nodes, we would be walking a different (and disconnected)
+graph than the one we built, and the search would strand itself. So rejected nodes are traversed through.
+
+5. **Line 15-16 — `e` only joins `W` if it is in the acceptList.** `W` is the *result* set, so this is the
+only place the predicate is allowed to have an opinion. This is the whole trick, and it is what the literature
+calls **in-filtering** (filter during traversal) as opposed to **post-filtering** (search, then discard).
+
+6. **Line 7 — the `│W│ = ef` guard.** We only stop early once `W` is *full*. This matters here in a way it
+never did for unfiltered search: `W` now only accepts matching nodes, so under a selective predicate it fills
+*slowly*. Without the guard, `f` (the furthest in `W`) is a very tight bound while `W` is still nearly empty,
+the stopping condition fires almost immediately, and the search gives up having found only a handful of
+results. Unfiltered, `W` fills on the first expansion, so this was never observable.
+
+7. **Upper layers are never filtered.** lc ← L … 1 is pure navigation with ef=1; its only job is to hand a
+good entry point to layer 0. Filtering there would mean the descent could fail to find *any* acceptable node
+at some upper layer and strand itself, when all it was ever supposed to do was get us to the right
+neighbourhood. Only layer 0 collects results, so only layer 0 filters.
+
+---
+
+## **Questions & Answers/Assumptions Made**
+
+### **Q1. Why not just search normally and drop the non-matching results afterwards?**
+
+That is post-filtering, and it is what we did originally. It does not work:
+
+* If the accepted vectors are all far from `q`, the top-K are all rejects and you return **nothing** —
+  even though plenty of vectors satisfied the predicate. The results are silently wrong, not just badly ordered.
+* The only way to defend against that with post-filtering is to over-search. But there is no over-search
+  factor that is *safe*: in the worst case the accepted vectors are the K **furthest** from `q`, so you would
+  have to retrieve the entire store to be sure of finding them.
+
+Post-filtering cannot give a guarantee at any price. In-filtering can, because `W` never fills with rejects
+in the first place.
+
+---
+
+### **Q2. Should `ef` be scaled up to compensate for the filter?**
+
+**No, and this is the trap.** `ef` is a quality/latency knob (paper §4, "the quality of the search is controlled
+by ... ef"). It is a *configured constant*, not a function of the data. Tying `ef` to `│acceptList│` means the
+breadth of a search is decided by how many rows the WHERE clause happened to match — a loose predicate
+(half the store) would drive `ef` into the tens of thousands and traverse essentially the whole graph to return
+10 results, which is slower than the linear scan HNSW exists to beat.
+
+`K` is what the caller asked for. `ef` is what we configured. Neither is derived from the predicate.
+
+---
+
+### **Q3. Then what happens when the predicate is very selective?**
+
+In-filtering degrades here, and honestly so: `W` can only fill with accepted nodes, so if very few nodes are
+acceptable, `W` never reaches `ef`, the stop condition (line 7) never fires, and the search keeps widening —
+approaching a full traversal to return a handful of results. The visited count grows roughly as `ef / selectivity`.
+
+That is exactly why line 3 exists. Below the threshold we abandon the graph and scan the accepted set directly:
+it is O(│acceptList│) distance computations, it is exact, and it is bounded. The graph is the wrong tool when
+the candidate set is already small.
+
+---
+
+### **Q4. How is the bruteForceThreshold chosen?**
+
+Currently a constant (4096). This is a **weak point and an open question** — see the open questions below.
+It should probably be relative to the size of the store, not absolute, since "selective" is a ratio, not a count.
+
+---
+
+### **Q5. Does this stay deterministic across replicas?**
+
+It must, per the determinism requirements in the testing strategy. Two places to be careful:
+
+* The brute-force path sorts by distance. Equal distances must **not** tie-break on hash-set iteration order.
+  We break ties on NodeId, which is a content hash and therefore stable across processes and restarts.
+* The acceptList itself is a set of NodeIds, so it is identical on every replica given the same data and the
+  same predicate.
+
+---
+
+### **Notes / Observations**
+
+* The acceptList is keyed by NodeId (u64), not by the vector, so membership is a single integer hash lookup on
+  the hot path and we never re-hash a 1024-dim vector during traversal.
+* Recall under a filter is *not* the same quantity as recall without one. The ground truth for a filtered query
+  is the true K nearest **among the accepted set**, i.e. brute force restricted to the acceptList. Any recall
+  test for this path must compare against that, not against the unfiltered brute force.
+* This algorithm has a hard requirement that alg. 2's `W` only ever contains accepted nodes — the stopping
+  condition reads `W`, so a single reject leaking into `W` corrupts the bound and silently truncates the search.
+
+---
+
+
 
 
 ## Data Model & API Interfaces:
@@ -779,6 +932,21 @@ impl Node {
 - How do we define a default for this value if not provided by the user? If a wrong default is chosen, do we recreate after we understand the dimensionality of said data??
   > @deven96's comment: Yeah we already know the dimensionality of the data so what i propose we do is surface some options as Option but if the values are not provided then we compute our defaults
 
+- **Filtered search (alg. 7): what should `bruteForceThreshold` actually be?** It is currently an absolute
+  constant (4096), which is crude — "selective" is a ratio, not a count. An acceptList of 5,000 is a loose
+  predicate on a 10k store and an extremely tight one on a 10M store, and only the second case wants the
+  graph. Options: make it relative (`max(4096, N/100)`), derive it from a cost model (estimated distance
+  computations for the scan vs. the expected `ef / selectivity` visits for the walk), or surface it as config.
+  Needs measurement across selectivities before we pick.
+
+- **Filtered search: should we cap the visited-node count?** At low selectivity but above the threshold,
+  in-filtering can still approach a full traversal. A visited cap would bound the latency at the cost of recall.
+  We have no data yet on where that trade sits, and a silent recall cliff is worse than a slow query, so it is
+  deliberately not implemented.
+
+- **Filtered search: is `ef` still the right knob under a filter?** `ef` accepted nodes is a different amount of
+  work than `ef` nodes. It may be that filtered queries want their own `ef` default. Open.
+
 
 
 ## **Testing Strategy**
@@ -855,7 +1023,42 @@ Compare our HNSW implementation against **FAISS’s HNSW** on the same dataset.
 
 ---
 
-#### **1.3. Optional / Advanced Correctness Checks**
+#### **1.3. Filtered Recall (Required for alg. 7)**
+
+Filtered search needs its own recall test, because **the ground truth is a different quantity**. For a filtered
+query the true answer is the K nearest **among the accepted set** — i.e. brute force restricted to the
+acceptList — *not* the K nearest overall. Comparing a filtered result against the unfiltered brute force will
+look like a recall collapse even when the implementation is perfect.
+
+```r
+FilteredRecall@K = (# of true accepted-neighbors returned in top K) / K
+    where true accepted-neighbors = brute-force KNN over acceptList only
+```
+
+**Procedure:**
+
+1. Build an index over a dataset.
+2. Pick an acceptList (a predicate) and sweep its **selectivity**: e.g. 100%, 50%, 10%, 1%, 0.1%.
+3. Ground truth: brute-force KNN restricted to the acceptList.
+4. Compare, and record both recall **and** latency at each selectivity.
+
+**The two cases that must be covered, because both were live bugs:**
+
+* **Adversarial placement (correctness).** Construct the acceptList so the accepted vectors are *far* from the
+  query and the rejected ones are *near* it (e.g. two separated clusters, query sitting in the rejected cluster,
+  predicate matching only the far cluster). A post-filtering implementation returns **zero** results here while
+  hundreds of vectors satisfy the predicate. This is the regression test for the original defect.
+* **Loose predicate (latency).** acceptList = ~half the store, K = 10. This must be *fast*: nearly everything
+  near the query is acceptable, so it should cost about what an unfiltered search costs. An implementation that
+  scales `ef` with `│acceptList│` blows up here — traversing the whole graph to return 10 rows, i.e. worse than
+  the linear scan HNSW is supposed to beat.
+
+> Latency must be asserted alongside recall for this path. A filtered search that is correct but traverses the
+> entire graph is still a failure — it silently turns the ANN index back into a linear scan.
+
+---
+
+#### **1.4. Optional / Advanced Correctness Checks**
 
 * **Sanity tests:** simple vectors, identical vectors, widely separated points.
 * **Structural integrity tests:** no duplicate neighbors, bidirectional edges, valid levels.


### PR DESCRIPTION
Draft. Filtered HNSW search set `k`/`ef` from the accept list size: a predicate matching rows outside the global top-k returned **zero** results, and a loose predicate walked the whole graph (8.58ms -> 38.7us on a 20k store, half accepted).

Now filters inside `search_layer` (rejected nodes still traversed, only accepted enter `W`), brute-forces highly selective predicates, and specs it as Algorithm 7.

Open: brute-force threshold is a magic 4096; unfiltered latency impact of the `|W| >= ef` guard unmeasured.