### PR TITLE
fix(replication): fsync raft log and vote writes before reporting success

### DIFF
--- a/ahnlich/replication/src/storage/rocksdb.rs
+++ b/ahnlich/replication/src/storage/rocksdb.rs
@@ -14,7 +14,7 @@ use openraft::{
     StorageIOError, Vote,
     storage::{LogFlushed, RaftLogStorage},
 };
-use rocksdb::{ColumnFamilyDescriptor, DB, IteratorMode, Options};
+use rocksdb::{ColumnFamilyDescriptor, DB, IteratorMode, Options, WriteBatch, WriteOptions};
 use serde_json::{from_slice, to_vec};
 
 use super::{LogIdOf, PersistedSnapshot, StateMachineSnapshotStore};
@@ -38,6 +38,19 @@ fn index_in_range<RB: RangeBounds<u64>>(range: &RB, idx: u64) -> bool {
         Bound::Unbounded => true,
     };
     start_ok && end_ok
+}
+
+// Write options that fsync the WAL before the write returns.
+//
+// Openraft requires the vote to be on disk before `save_vote` returns, and the
+// appended entries to be on disk before `LogFlushed::log_io_completed` fires.
+// RocksDB's default write options only reach the OS page cache, which a machine
+// crash discards: a lost vote lets this node vote twice in one term, and lost
+// entries drop data the leader already reported as committed.
+fn sync_write_opts() -> WriteOptions {
+    let mut opts = WriteOptions::default();
+    opts.set_sync(true);
+    opts
 }
 
 // RocksDB-backed log store. Production default. Persists Raft log entries and
@@ -119,7 +132,7 @@ impl<C: RaftTypeConfig> RocksLogStore<C> {
             source: StorageIOError::write_logs(&e),
         })?;
         self.db
-            .put_cf(self.cf_meta()?, key.as_bytes(), bytes)
+            .put_cf_opt(self.cf_meta()?, key.as_bytes(), bytes, &sync_write_opts())
             .map_err(|e| StorageError::IO {
                 source: StorageIOError::write_logs(&e),
             })
@@ -253,16 +266,22 @@ where
         I: IntoIterator<Item = C::Entry>,
     {
         let cf = self.cf_logs()?;
+        // One batch, one fsync: the whole append must be durable before the
+        // caller reports completion to openraft, and a per-entry sync would pay
+        // one fsync per log entry instead of one per append.
+        let mut batch = WriteBatch::default();
         for entry in entries {
             let key = Self::key(entry.get_log_id().index);
             let val = to_vec(&entry).map_err(|e| StorageError::IO {
                 source: StorageIOError::write_logs(&e),
             })?;
-            self.db.put_cf(cf, key, val).map_err(|e| StorageError::IO {
-                source: StorageIOError::write_logs(&e),
-            })?;
+            batch.put_cf(cf, key, val);
         }
-        Ok(())
+        self.db
+            .write_opt(batch, &sync_write_opts())
+            .map_err(|e| StorageError::IO {
+                source: StorageIOError::write_logs(&e),
+            })
     }
 
     fn delete_conflict_logs_since_sync(
@@ -271,12 +290,18 @@ where
     ) -> Result<(), StorageError<C::NodeId>> {
         let cf = self.cf_logs()?;
         let keys = self.collect_log_keys_matching(|idx| idx >= log_id.index)?;
+        // Durable before returning: if a crash loses the truncation, the
+        // conflicting tail comes back and `get_log_state` reports a last_log_id
+        // this node never accepted from the current leader.
+        let mut batch = WriteBatch::default();
         for key in keys {
-            self.db.delete_cf(cf, key).map_err(|e| StorageError::IO {
-                source: StorageIOError::write_logs(&e),
-            })?;
+            batch.delete_cf(cf, key);
         }
-        Ok(())
+        self.db
+            .write_opt(batch, &sync_write_opts())
+            .map_err(|e| StorageError::IO {
+                source: StorageIOError::write_logs(&e),
+            })
     }
 
     pub(crate) fn purge_logs_upto_sync(
@@ -285,11 +310,15 @@ where
     ) -> Result<(), StorageError<C::NodeId>> {
         let cf = self.cf_logs()?;
         let keys = self.collect_log_keys_matching(|idx| idx <= log_id.index)?;
+        let mut batch = WriteBatch::default();
         for key in keys {
-            self.db.delete_cf(cf, key).map_err(|e| StorageError::IO {
+            batch.delete_cf(cf, key);
+        }
+        self.db
+            .write_opt(batch, &sync_write_opts())
+            .map_err(|e| StorageError::IO {
                 source: StorageIOError::write_logs(&e),
             })?;
-        }
         self.put_last_purged_log_id(Some(log_id))
     }
 


### PR DESCRIPTION
## Problem

`RocksLogStore` (`ahnlich/replication/src/storage/rocksdb.rs`) writes with RocksDB's default `WriteOptions`, which return once the record is in the OS page cache. Openraft treats a successful storage call as proof the data is on disk:

- [`RaftLogStorage::save_vote`](https://docs.rs/openraft/0.9/openraft/storage/trait.RaftLogStorage.html#tymethod.save_vote) — *"The vote must be persisted on disk before returning"*
- `append` — the entries must be on disk before `LogFlushed::log_io_completed` fires

Two failure modes on power loss or kernel panic (a clean shutdown is fine, RocksDB flushes on close):

1. **Double vote in one term.** `save_vote` returns `Ok` with the vote only in the page cache. After the crash the node reads back an older vote and grants its vote again in the same term — two candidates can each collect a majority and both become leader for that term.
2. **Loss of acknowledged data.** The leader returns success to the client once a quorum, including this node, reports the append durable. If several nodes lose power together (same rack, whole-cluster restart), entries reported as committed are gone.

Neither shows up in testing — everything works on a graceful shutdown, and the existing store tests pass either way.

## Fix

A `sync_write_opts()` helper returning `WriteOptions` with `set_sync(true)`, applied to every durable-state write:

| write | before | after |
|---|---|---|
| `put_meta` (vote, committed, last_purged_log_id) | `put_cf` | `put_cf_opt` |
| `append_to_log_sync` | `put_cf` per entry | one `WriteBatch` + `write_opt` |
| `delete_conflict_logs_since_sync` | `delete_cf` per key | one `WriteBatch` + `write_opt` |
| `purge_logs_upto_sync` | `delete_cf` per key | one `WriteBatch` + `write_opt` |

Batching is not cosmetic here — without it, adding `sync` would cost **one fsync per log entry**. With it, an append costs one fsync per batch, which is the normal price of a raft log; openraft already batches entries before calling `append`.

The two delete paths need durability as well: if a crash loses a truncation, the conflicting tail comes back and `get_log_state` reports a `last_log_id` this node never accepted from the current leader.

## Verification

```
cargo check -p ahnlich-replication
cargo test  -p ahnlich-replication --lib     # 9 passed, 0 failed
```

Durability itself cannot be asserted from inside the process — a test would have to kill the machine, not the process — so the change is instead scoped so that every write to the log store goes through one helper.

---

Found while reviewing how projects use openraft (I maintain [openraft](https://github.com/databendlabs/openraft)). Unrelated to this PR, but worth saying: the `ClusterLifecycle { Bootstrap, Join, Existing }` model in `replication/src/config.rs` is the cleanest treatment of cluster bootstrap I found across the projects I looked at — most either auto-bootstrap when a peer probe fails (split-brain risk) or bury the decision in hundreds of lines of init code.
