### PR TITLE
Migraph X followup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,17 @@ jobs:
       outputs:
         bin_name: ${{ steps.get_binary_type.outputs.BIN_NAME }}
         bin_suffix: ${{ steps.get_binary_type.outputs.BIN_SUFFIX }}
+        rust_version: ${{ steps.rust_version.outputs.RUST_VERSION }}
       steps:
           - name: "Checkout"
             uses: actions/checkout@v4
+
+          - name: "Get Rust version from toolchain file"
+            id: rust_version
+            working-directory: ./ahnlich
+            run: |
+                VERSION=$(grep -E '^channel\s*=' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
+                echo "RUST_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
           - name: "Get Binary Type"
             id: get_binary_type
@@ -56,7 +64,7 @@ jobs:
             - name: Get Cargo toolchain
               uses: actions-rs/toolchain@v1
               with:
-                toolchain: 1.97.1
+                toolchain: ${{ needs.prebuild_preparation.outputs.rust_version }}
 
             - name: Build Linux Release for ${{ needs.prebuild_preparation.outputs.bin_name }}
               working-directory: ./ahnlich
@@ -91,7 +99,7 @@ jobs:
           - name: Get Cargo toolchain
             uses: actions-rs/toolchain@v1
             with:
-              toolchain: 1.97.1
+              toolchain: ${{ needs.prebuild_preparation.outputs.rust_version }}
               target: wasm32-unknown-unknown
 
           - name: Install wasm-pack
@@ -177,6 +185,7 @@ jobs:
               build-args: |
                 AHNLICH_BIN=${{ needs.prebuild_preparation.outputs.bin_name}}
                 DEFAULT_PORT=${{env.DEFAULT_PORT}}
+                RUST_VERSION=${{ needs.prebuild_preparation.outputs.rust_version }}
 
           - name: Generate artifact attestation
             uses: actions/attest-build-provenance@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         bin_name: ${{ steps.get_binary_type.outputs.BIN_NAME }}
         bin_suffix: ${{ steps.get_binary_type.outputs.BIN_SUFFIX }}
         rust_version: ${{ steps.rust_version.outputs.RUST_VERSION }}
+        ort_version: ${{ steps.ort_version.outputs.ORT_VERSION }}
       steps:
           - name: "Checkout"
             uses: actions/checkout@v4
@@ -27,6 +28,11 @@ jobs:
             run: |
                 VERSION=$(grep -E '^channel\s*=' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
                 echo "RUST_VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+          - name: "Set ORT version"
+            id: ort_version
+            run: |
+                echo "ORT_VERSION=1.23.2" >> $GITHUB_OUTPUT
 
           - name: "Get Binary Type"
             id: get_binary_type
@@ -117,9 +123,9 @@ jobs:
             env:
               GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-    push_to_registries:
+    push_to_registries_cuda:
         needs: prebuild_preparation
-        name: Push Docker image to multiple registries
+        name: Push Docker image (CUDA) to multiple registries
         runs-on: ubuntu-latest
         if: ${{needs.prebuild_preparation.outputs.bin_name != 'ahnlich-cli'}}
         permissions:
@@ -186,10 +192,85 @@ jobs:
                 AHNLICH_BIN=${{ needs.prebuild_preparation.outputs.bin_name}}
                 DEFAULT_PORT=${{env.DEFAULT_PORT}}
                 RUST_VERSION=${{ needs.prebuild_preparation.outputs.rust_version }}
+                ORT_VER=${{ needs.prebuild_preparation.outputs.ort_version }}
 
           - name: Generate artifact attestation
             uses: actions/attest-build-provenance@v1
             with:
-              subject-name: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}
+              subject-name: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}:${{env.BIN_VERSION}}
+              subject-digest: ${{ steps.push.outputs.digest }}
+              push-to-registry: true
+
+    push_to_registries_migraphx:
+        needs: prebuild_preparation
+        name: Push Docker image (MIGraphX) to multiple registries
+        runs-on: ubuntu-latest
+        if: ${{needs.prebuild_preparation.outputs.bin_name == 'ahnlich-ai'}}
+        permissions:
+          packages: write
+          contents: read
+          attestations: write
+          id-token: write
+        steps:
+          - name: Check out the repo
+            uses: actions/checkout@v4
+          
+          - name: Cache Docker images
+            uses: ScribeMD/docker-cache@0.5.0
+            with:
+              key: ${{ runner.os }}-cargo-${{ hashFiles('ahnlich/Cargo.lock') }}-migraphx
+
+          - name: Set Port Based on Bin Name
+            id: set_port
+            run: |
+              echo "DEFAULT_PORT=1370" >> $GITHUB_ENV
+              echo "DESCRIPTION=Ahnlich AI (MIGraphX)" >> $GITHUB_ENV
+
+          - name: Extract version number from tag
+            id: extract_version
+            run: |
+              # Extract version from release tag (format: bin/<suffix>/<version>)
+              VERSION=$(echo "${{ github.event.release.tag_name }}" | cut -d'/' -f3)
+              echo $VERSION
+              echo "BIN_VERSION=$VERSION" >> $GITHUB_ENV
+
+          - name: Log in to the Container registry
+            uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
+            with:
+              registry: ghcr.io
+              username: ${{ github.repository_owner }}
+              password: ${{ secrets.GH_GCR_TOKEN }}
+
+          
+          - name: Extract metadata (tags, labels) for Docker
+            id: meta
+            uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+            with:
+              images: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}
+              tags: |
+                type=raw,value=${{env.BIN_VERSION}}-migraphx
+                type=raw,value=latest-migraphx
+              labels: |
+                org.opencontainers.image.description=${{ env.DESCRIPTION }}
+
+          - name: Build and push Docker images
+            id: push
+            uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85
+            with:
+              context: ./ahnlich
+              file: ./ahnlich/Dockerfile.migraphx
+              push: true
+              tags: ${{ steps.meta.outputs.tags }}
+              labels: ${{ steps.meta.outputs.labels }}
+              build-args: |
+                AHNLICH_BIN=${{ needs.prebuild_preparation.outputs.bin_name}}
+                DEFAULT_PORT=${{env.DEFAULT_PORT}}
+                RUST_VERSION=${{ needs.prebuild_preparation.outputs.rust_version }}
+                ORT_VER=${{ needs.prebuild_preparation.outputs.ort_version }}
+
+          - name: Generate artifact attestation
+            uses: actions/attest-build-provenance@v1
+            with:
+              subject-name: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}:${{env.BIN_VERSION}}-migraphx
               subject-digest: ${{ steps.push.outputs.digest }}
               push-to-registry: true

--- a/.github/workflows/rust_tag_and_deploy.yml
+++ b/.github/workflows/rust_tag_and_deploy.yml
@@ -14,11 +14,19 @@ jobs:
       client_version: ${{ steps.get_version.outputs.CLIENT_VERSION }}
       client_version_changed: ${{ steps.check_version_changes.outputs.CLIENT_VERSION_CHANGED }}
       tag_version: ${{ steps.get_version.outputs.TAG_VERSION }}
+      rust_version: ${{ steps.rust_version.outputs.RUST_VERSION }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Get Rust version from toolchain file
+        id: rust_version
+        working-directory: ./ahnlich
+        run: |
+          VERSION=$(grep -E '^channel\s*=' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "RUST_VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Check for changes in rust client toml
         id: check_version_changes
@@ -66,7 +74,7 @@ jobs:
       - name: Get Cargo toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.97.1
+          toolchain: ${{ needs.check_version_changes_and_tag.outputs.rust_version }}
 
       - name: Install protoc
         run: |

--- a/ahnlich/Dockerfile
+++ b/ahnlich/Dockerfile
@@ -1,4 +1,5 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.88.0 AS chef
+ARG RUST_VERSION
+FROM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION} AS chef
 WORKDIR /app
 RUN apt update && apt install lld clang protobuf-compiler -y 
 FROM chef AS planner
@@ -31,6 +32,7 @@ FROM debian:trixie-slim AS runtime
 
 ARG AHNLICH_BIN
 ARG DEFAULT_PORT
+ARG ORT_VER=1.23.2
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates \
@@ -43,7 +45,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-cert
 
 # ✅ Conditionally install onnxruntime from github if AHNLICH_BIN=ahnlich-ai
 RUN if [ "$AHNLICH_BIN" = "ahnlich-ai" ]; then \
-  ORT_VER=1.19.0 && \
   curl -L -o /tmp/ort.tgz \
   https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VER}/onnxruntime-linux-x64-gpu-${ORT_VER}.tgz && \
   mkdir -p /opt/onnxruntime && \

--- a/ahnlich/Dockerfile.migraphx
+++ b/ahnlich/Dockerfile.migraphx
@@ -124,7 +124,6 @@ RUN if [ "$AHNLICH_BIN" = "ahnlich-ai" ]; then \
   mkdir -p /opt/onnxruntime-rocm && \
   unzip -q /tmp/${WHL} -d /opt/onnxruntime-rocm && \
   cp /opt/onnxruntime-rocm/onnxruntime/capi/libonnxruntime*.so* /lib/ && \
-  cp /opt/onnxruntime-rocm/onnxruntime_rocm.libs/*.so* /lib/ && \
   MAIN_LIB=$(ls /lib/libonnxruntime.so.* 2>/dev/null | head -1) && \
   ln -sf ${MAIN_LIB} /lib/libonnxruntime.so && \
   ldconfig && \

--- a/ahnlich/Dockerfile.migraphx
+++ b/ahnlich/Dockerfile.migraphx
@@ -1,14 +1,14 @@
-# Dockerfile.rocm — ahnlich-ai with a ROCm-stack ONNX Runtime bundle
+# Dockerfile.migraphx — ahnlich-ai with a ROCm-stack ONNX Runtime bundle
 # exposing the MIGraphX execution provider for AMD GPUs.
 #
 # This image is self-contained for AMD GPU inference: the runtime stage
-# is based on AMD's rocm/dev-ubuntu-24.04 image (which ships ROCm 6.4.2 +
+# is based on AMD's rocm/dev-ubuntu-24.04 image (which ships ROCm 7.2.1 +
 # HIP + rocBLAS + MIOpen + ...), and we drop AMD's prebuilt onnxruntime
 # ROCm wheel libraries on top of it.
 #
-# ROCm 6.4.2 is the minimum release with RDNA4 (gfx1200/gfx1201, e.g.
+# ROCm 7.2.1 is a release with (gfx1200/gfx1201, e.g.
 # Radeon RX 9070) support; it also covers RDNA3 (gfx1100) and CDNA. The
-# matching AMD onnxruntime_rocm wheel is 1.21.0, which ships the MIGraphX
+# matching AMD onnxruntime_migraphx wheel is 1.23.2, which ships the MIGraphX
 # execution provider (upstream removed the older ROCm EP in ORT 1.23;
 # ahnlich only exposes MIGraphX).
 #
@@ -16,17 +16,17 @@
 # loads libonnxruntime via dlopen (ORT_DYLIB_PATH). The ORT C API is
 # forward compatible — a newer libonnxruntime serves older API
 # requests — and dlopen sidesteps the ELF symbol-version (VERS_1.19.0)
-# check that link-time loading would enforce against the 1.21 library.
+# check that link-time loading would enforce against the 1.23.2 library.
 #
 # The default Dockerfile ships a CUDA-flavour ONNX Runtime tarball. This
 # file is its AMD sibling — the choice of which image to run is made at
 # deployment time, not at compile time.
 #
 # Build:
-#   docker build -f Dockerfile.rocm \
+#   docker build -f Dockerfile.migraphx \
 #     --build-arg AHNLICH_BIN=ahnlich-ai \
 #     --build-arg DEFAULT_PORT=1370 \
-#     -t ahnlich-ai:rocm .
+#     -t ahnlich-ai:migraphx .
 #
 # Run (host needs a supported AMD GPU; ROCm runtime is bundled in the
 # image, but the kernel driver (/dev/kfd) and DRM devices must be
@@ -35,7 +35,7 @@
 #     --device /dev/kfd --device /dev/dri \
 #     --group-add video \
 #     -p 1370:1370 \
-#     ahnlich-ai:rocm \
+#     ahnlich-ai:migraphx \
 #     ahnlich-ai run --host 0.0.0.0
 #
 # Then point clients at the MIGRAPHX execution provider.
@@ -44,7 +44,8 @@
 # device kernels + the ORT provider libraries). Most of that is the AMD
 # device kernels and is unavoidable.
 
-FROM lukemathwalker/cargo-chef:latest-rust-1.88.0 AS chef
+ARG RUST_VERSION
+FROM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION} AS chef
 WORKDIR /app
 RUN apt update && apt install lld clang protobuf-compiler -y
 
@@ -78,20 +79,20 @@ RUN if [ "$AHNLICH_BIN" = "ahnlich-ai" ]; then \
 RUN cargo build --release --bin ahnlich-cli
 
 
-# AMD's ROCm 6.4.2 dev image. Bundles libhsa, libamdhip64, rocBLAS,
+# AMD's ROCm 7.2.1 dev image. Bundles libhsa, libamdhip64, rocBLAS,
 # MIOpen, etc. — the system libraries the ROCm execution provider needs
 # at session creation. This base intentionally matches the ROCm release
-# directory we download the onnxruntime wheel from (rocm-rel-6.4.2).
+# directory we download the onnxruntime wheel from (rocm-rel-7.2.1).
 #
 # Ubuntu 24.04 (glibc 2.39) satisfies the wheel's manylinux_2_28
 # baseline.
-FROM rocm/dev-ubuntu-24.04:6.4.2 AS runtime
+FROM rocm/dev-ubuntu-24.04:7.2.1 AS runtime
 
 ARG AHNLICH_BIN
 ARG DEFAULT_PORT
-ARG ORT_VER=1.21.0
+ARG ORT_VER=1.23.2
 ARG ORT_PY=cp312
-ARG ROCM_REL=rocm-rel-6.4.2
+ARG ROCM_REL=rocm-rel-7.2.1
 WORKDIR /app
 
 # Extra apt deps beyond the rocm/dev base image:
@@ -109,7 +110,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
-# Pull AMD's prebuilt onnxruntime-rocm wheel and extract just the shared
+# Pull AMD's prebuilt onnxruntime-migraphx wheel and extract just the shared
 # libraries we need. The wheel itself is a Python distribution; we are
 # only after the C/C++ runtime artefacts.
 #
@@ -117,7 +118,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # binary may request (built against the 1.19-era ORT API); the ORT C
 # API is forward compatible across these versions.
 RUN if [ "$AHNLICH_BIN" = "ahnlich-ai" ]; then \
-  WHL="onnxruntime_rocm-${ORT_VER}-${ORT_PY}-${ORT_PY}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" && \
+  WHL="onnxruntime_migraphx-${ORT_VER}-${ORT_PY}-${ORT_PY}-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl" && \
   curl -fSL -o /tmp/${WHL} \
     "https://repo.radeon.com/rocm/manylinux/${ROCM_REL}/${WHL}" && \
   mkdir -p /opt/onnxruntime-rocm && \

--- a/ahnlich/scripts/get-rust-version.sh
+++ b/ahnlich/scripts/get-rust-version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Get the directory where this script lives
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLCHAIN_FILE="${SCRIPT_DIR}/../rust-toolchain.toml"
+
+if [[ ! -f "$TOOLCHAIN_FILE" ]]; then
+    echo "Error: rust-toolchain.toml not found at $TOOLCHAIN_FILE" >&2
+    exit 1
+fi
+
+# Extract version from: channel = "1.97.1"
+grep -E '^channel\s*=' "$TOOLCHAIN_FILE" | sed 's/.*"\(.*\)".*/\1/'

--- a/sdk/ahnlich-client-node/Makefile
+++ b/sdk/ahnlich-client-node/Makefile
@@ -13,9 +13,7 @@ format:
 format-check:
 	npx prettier --check "src/**/*.ts" "tests/**/*.ts" "grpc/**/*.ts"
 
-lint-check: format-check
-
-pre-commit-check: lint-check
+pre-commit-check: format-check
 
 generate:
 	@echo "➜ Generating TypeScript protobuf code from proto definitions"

--- a/sdk/ahnlich-client-node/grpc/ai/execution_provider_pb.ts
+++ b/sdk/ahnlich-client-node/grpc/ai/execution_provider_pb.ts
@@ -49,4 +49,3 @@ proto3.util.setEnumType(ExecutionProvider, "ai.execution_provider.ExecutionProvi
   { no: 3, name: "CORE_ML" },
   { no: 5, name: "MIGRAPHX" },
 ]);
-


### PR DESCRIPTION
- Centralize rust version handling of CI release to parse toolchain
- Bumping ORT version to 1.23.2
- Including docker image releases of `ahnlich-ai:{version}-migraphx` 

Should close #388 cc @Benehiko 