### PR TITLE
Release ahnlich_client_rs and ahnlich_types 0.4.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
           - name: Generate artifact attestation
             uses: actions/attest-build-provenance@v1
             with:
-              subject-name: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}:${{env.BIN_VERSION}}
+              subject-name: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}
               subject-digest: ${{ steps.push.outputs.digest }}
               push-to-registry: true
 
@@ -271,6 +271,6 @@ jobs:
           - name: Generate artifact attestation
             uses: actions/attest-build-provenance@v1
             with:
-              subject-name: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}:${{env.BIN_VERSION}}-migraphx
+              subject-name: ghcr.io/${{ github.repository_owner }}/${{needs.prebuild_preparation.outputs.bin_name}}
               subject-digest: ${{ steps.push.outputs.digest }}
               push-to-registry: true

--- a/ahnlich/Cargo.lock
+++ b/ahnlich/Cargo.lock
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "ahnlich_client_rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ahnlich_types",
  "ai",
@@ -142,7 +142,7 @@ dependencies = [
 
 [[package]]
 name = "ai"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "ahnlich_client_rs",
  "ahnlich_types",

--- a/ahnlich/ai/Cargo.toml
+++ b/ahnlich/ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 
 

--- a/ahnlich/ai/src/server/handler.rs
+++ b/ahnlich/ai/src/server/handler.rs
@@ -1153,7 +1153,10 @@ impl AIProxyServer {
     async fn build_db_client(config: &AIProxyConfig) -> DbClient {
         let scheme = if config.db_https { "https" } else { "http" };
         let addr = format!("{scheme}://{}:{}", config.db_host, config.db_port);
-        let mut client = DbClient::new(addr).await.expect("Cannot start DB client");
+        let message_size = Some(config.common.message_size);
+        let mut client = DbClient::new_with_message_size(addr, message_size, message_size)
+            .await
+            .expect("Cannot start DB client");
 
         if let (Some(username), Some(api_key)) = (&config.db_auth_username, &config.db_auth_key) {
             client.set_auth_token(format!("{}:{}", username, api_key));

--- a/ahnlich/client/Cargo.toml
+++ b/ahnlich/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahnlich_client_rs"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Diretnan Domnan <diretnandomnan@gmail.com>"]
 categories = ["database-implementations", "database", "web-programming"]
 keywords = ["ahnlich", "in-memory", "ai"]

--- a/ahnlich/types/Cargo.toml
+++ b/ahnlich/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahnlich_types"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Diretnan Domnan <diretnandomnan@gmail.com>"]
 categories = ["database-implementations", "database", "web-programming"]
 keywords = ["ahnlich", "in-memory", "ai"]


### PR DESCRIPTION
## Changes

- Add `new_with_message_size()` method to `DbClient` and `AiClient` to allow configuring message size limits separately for encoding and decoding
- Update ahnlich-ai to use configured message size when connecting to ahnlich-db internally
- Fix attestation subject-name in release workflow to exclude version tag
- Bump ahnlich_client_rs: 0.4.1 → 0.4.2
- Bump ahnlich_types: 0.4.1 → 0.4.2
- Bump ai binary: 0.4.1 → 0.4.2

This fixes the message size limit issue where clients were limited to 4MB (tonic default) even though servers were configured for 30MB.