### PR TITLE
Trigger client 0.4.2 release to crates.io

### DIFF
--- a/ahnlich/client/Cargo.toml
+++ b/ahnlich/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahnlich_client_rs"
-version = "0.4.2"
+version = "0.4.2" 
 authors = ["Diretnan Domnan <diretnandomnan@gmail.com>"]
 categories = ["database-implementations", "database", "web-programming"]
 keywords = ["ahnlich", "in-memory", "ai"]


### PR DESCRIPTION
The previous PR's merge commit only touched types/Cargo.toml, so the workflow didn't detect the client version change. This PR adds a whitespace change to client/Cargo.toml to trigger the release workflow for version 0.4.2.