### PR TITLE
Publish ahnlich_client_rs and ahnlich_types 0.4.3 to crates.io

### DIFF
--- a/ahnlich/client/Cargo.toml
+++ b/ahnlich/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahnlich_client_rs"
-version = "0.4.2" 
+version = "0.4.3"
 authors = ["Diretnan Domnan <diretnandomnan@gmail.com>"]
 categories = ["database-implementations", "database", "web-programming"]
 keywords = ["ahnlich", "in-memory", "ai"]

--- a/ahnlich/client/Cargo.toml
+++ b/ahnlich/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahnlich_client_rs"
-version = "0.4.2"
+version = "0.4.2" 
 authors = ["Diretnan Domnan <diretnandomnan@gmail.com>"]
 categories = ["database-implementations", "database", "web-programming"]
 keywords = ["ahnlich", "in-memory", "ai"]

--- a/ahnlich/client/Cargo.toml
+++ b/ahnlich/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahnlich_client_rs"
-version = "0.4.2" 
+version = "0.4.2"
 authors = ["Diretnan Domnan <diretnandomnan@gmail.com>"]
 categories = ["database-implementations", "database", "web-programming"]
 keywords = ["ahnlich", "in-memory", "ai"]

--- a/ahnlich/types/Cargo.toml
+++ b/ahnlich/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ahnlich_types"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Diretnan Domnan <diretnandomnan@gmail.com>"]
 categories = ["database-implementations", "database", "web-programming"]
 keywords = ["ahnlich", "in-memory", "ai"]


### PR DESCRIPTION
Bumping to 0.4.3 to trigger the release workflow and publish to crates.io with the message size configuration changes.