### PR TITLE
Update MCP release workflow

### DIFF
--- a/.github/workflows/mcp_tag_and_deploy.yml
+++ b/.github/workflows/mcp_tag_and_deploy.yml
@@ -1,10 +1,12 @@
 name: Ahnlich MCP Tag and Deploy
 
 on:
-  pull_request:
+  push:
     branches: ["main"]
-    types:
-      - closed
+    paths:
+      - "mcp/**"
+      - ".github/workflows/mcp_tag_and_deploy.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,7 +18,6 @@ concurrency:
 jobs:
   release_metadata:
     name: Check version and create tag
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -24,19 +25,19 @@ jobs:
       contents: write
 
     outputs:
-      mcp_version: ${{ steps.check_version.outputs.mcp_version }}
-      version_changed: ${{ steps.check_version.outputs.version_changed }}
-      tag_name: ${{ steps.check_version.outputs.tag_name }}
+      mcp_version: ${{ steps.check_release.outputs.mcp_version }}
+      should_release: ${{ steps.check_release.outputs.should_release }}
+      tag_name: ${{ steps.check_release.outputs.tag_name }}
 
     defaults:
       run:
         working-directory: ./mcp
 
     steps:
-      - name: Check out merged commit
+      - name: Check out release commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -44,51 +45,67 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Check MCP version
-        id: check_version
+      - name: Check MCP release
+        id: check_release
         shell: bash
+        env:
+          BASE_REF: ${{ github.event.before }}
         run: |
           set -euo pipefail
-
-          BASE_REF="${{ github.event.pull_request.base.sha }}"
-
-          if git cat-file -e "${BASE_REF}:mcp/pyproject.toml" 2>/dev/null; then
-            BASE_VERSION=$(
-              git show "${BASE_REF}:mcp/pyproject.toml" |
-                python -c \
-                  'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["project"]["version"])'
-            )
-          else
-            BASE_VERSION=""
-          fi
 
           MCP_VERSION=$(
             python -c \
               'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])'
           )
+          TAG_NAME="mcp/${MCP_VERSION}"
+          HEAD_COMMIT=$(git rev-parse HEAD)
+          BASE_VERSION=""
 
-          echo "Previous version: ${BASE_VERSION:-not published}"
+          if [[ -n "${BASE_REF}" ]] \
+            && [[ "${BASE_REF}" != "0000000000000000000000000000000000000000" ]] \
+            && git cat-file -e "${BASE_REF}:mcp/pyproject.toml" 2>/dev/null; then
+            BASE_VERSION=$(
+              git show "${BASE_REF}:mcp/pyproject.toml" |
+                python -c \
+                  'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["project"]["version"])'
+            )
+          fi
+
+          echo "Previous version: ${BASE_VERSION:-not available}"
           echo "Current version: ${MCP_VERSION}"
 
           echo "mcp_version=${MCP_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag_name=mcp/${MCP_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
-          if [[ "${BASE_VERSION}" == "${MCP_VERSION}" ]]; then
-            echo "version_changed=false" >> "$GITHUB_OUTPUT"
+          if git rev-parse --verify --quiet "refs/tags/${TAG_NAME}" >/dev/null; then
+            TAG_COMMIT=$(git rev-list -n 1 "${TAG_NAME}")
+
+            if [[ "${TAG_COMMIT}" == "${HEAD_COMMIT}" ]]; then
+              echo "Tag ${TAG_NAME} already points to this commit; retrying release."
+              echo "should_release=true" >> "$GITHUB_OUTPUT"
+            elif [[ -n "${BASE_VERSION}" ]] \
+              && [[ "${BASE_VERSION}" != "${MCP_VERSION}" ]]; then
+              echo "::error::Tag ${TAG_NAME} already points to another commit."
+              exit 1
+            else
+              echo "Version ${MCP_VERSION} is already released; skipping."
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "version_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG_NAME} does not exist; starting release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create release tag
-        if: steps.check_version.outputs.version_changed == 'true'
+        if: steps.check_release.outputs.should_release == 'true'
         shell: bash
         run: |
           set -euo pipefail
 
-          TAG_NAME="${{ steps.check_version.outputs.tag_name }}"
+          TAG_NAME="${{ steps.check_release.outputs.tag_name }}"
           HEAD_COMMIT=$(git rev-parse HEAD)
 
-          if git rev-parse --verify --quiet "refs/tags/${TAG_NAME}"; then
+          if git rev-parse --verify --quiet "refs/tags/${TAG_NAME}" >/dev/null; then
             TAG_COMMIT=$(git rev-list -n 1 "${TAG_NAME}")
 
             if [[ "${TAG_COMMIT}" != "${HEAD_COMMIT}" ]]; then
@@ -100,19 +117,19 @@ jobs:
             exit 0
           fi
 
-          git config user.name "${{ github.actor }}"
-          git config user.email \
-            "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git tag -a "${TAG_NAME}" \
-            -m "ahnlich-mcp v${{ steps.check_version.outputs.mcp_version }}"
+          git tag \
+            --annotate "${TAG_NAME}" \
+            --message "Release Ahnlich MCP ${{ steps.check_release.outputs.mcp_version }}"
 
           git push origin "${TAG_NAME}"
 
   build_distribution:
     name: Build Python distributions
     needs: release_metadata
-    if: needs.release_metadata.outputs.version_changed == 'true'
+    if: needs.release_metadata.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -126,41 +143,30 @@ jobs:
         with:
           ref: ${{ needs.release_metadata.outputs.tag_name }}
 
-      - name: Install uv and Python
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@088076d5f5d185d7d24377be3c1ef24d38f0c8c3
         with:
           version: "0.11.31"
-          python-version: "3.11"
           enable-cache: true
           cache-dependency-glob: "mcp/uv.lock"
 
-      - name: Install project
-        run: uv sync --locked --dev
-
-      - name: Run unit tests
-        run: uv run pytest tests/unit -v
-
       - name: Build distributions
-        run: uv build --no-sources
+        run: uv build
 
-      - name: Smoke test wheel
-        shell: bash
+      - name: Verify distributions
         run: |
-          set -euo pipefail
-
-          WHEEL=$(find dist -maxdepth 1 -name "*.whl" -print -quit)
-          test -n "${WHEEL}"
-
-          uv run \
-            --isolated \
-            --no-project \
-            --with "${WHEEL}" \
-            -- ahnlich-mcp --help
+          uvx twine check dist/*
+          uvx check-wheel-contents dist/*.whl
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4
         with:
-          name: ahnlich-mcp-${{ needs.release_metadata.outputs.mcp_version }}
+          name: ahnlich-mcp-distributions
           path: mcp/dist/*
           if-no-files-found: error
           retention-days: 7
@@ -168,7 +174,7 @@ jobs:
   container_smoke_test:
     name: Build and test container
     needs: release_metadata
-    if: needs.release_metadata.outputs.version_changed == 'true'
+    if: needs.release_metadata.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -181,48 +187,50 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build local test image
+      - name: Build local container
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85
         with:
           context: ./mcp
+          file: ./mcp/Dockerfile
           load: true
           push: false
-          tags: ahnlich-mcp:smoke-test
-          cache-from: type=gha,scope=ahnlich-mcp
-          cache-to: type=gha,mode=max,scope=ahnlich-mcp
+          tags: ahnlich-mcp:release-test
 
-      - name: Smoke test image
-        run: docker run --rm ahnlich-mcp:smoke-test --help
-
-      - name: Verify non-root runtime
-        shell: bash
+      - name: Test container
         run: |
           set -euo pipefail
 
-          USER=$(docker image inspect \
-            ahnlich-mcp:smoke-test \
-            --format '{{.Config.User}}')
+          docker run --rm ahnlich-mcp:release-test --help
 
-          test "${USER}" = "ahnlich"
+          USER_NAME=$(
+            docker image inspect ahnlich-mcp:release-test \
+              --format '{{.Config.User}}'
+          )
+
+          test "${USER_NAME}" = "ahnlich"
 
   publish_python:
     name: Publish to PyPI
     needs:
       - release_metadata
       - build_distribution
-    if: needs.release_metadata.outputs.version_changed == 'true'
+    if: needs.release_metadata.outputs.should_release == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ahnlich-mcp/${{ needs.release_metadata.outputs.mcp_version }}/
 
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v4
         with:
-          name: ahnlich-mcp-${{ needs.release_metadata.outputs.mcp_version }}
+          name: ahnlich-mcp-distributions
           path: dist
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Set up uv
+        uses: astral-sh/setup-uv@088076d5f5d185d7d24377be3c1ef24d38f0c8c3
         with:
           version: "0.11.31"
 
@@ -237,15 +245,19 @@ jobs:
       - release_metadata
       - container_smoke_test
       - publish_python
-    if: needs.release_metadata.outputs.version_changed == 'true'
+    if: needs.release_metadata.outputs.should_release == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     permissions:
       contents: read
       packages: write
-      attestations: write
       id-token: write
+      attestations: write
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/ahnlich-mcp
 
     steps:
       - name: Check out release tag
@@ -262,38 +274,33 @@ jobs:
       - name: Log in to GHCR
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GH_GCR_TOKEN }}
 
-      - name: Generate image metadata
+      - name: Generate container metadata
         id: metadata
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b8a9ee401d9b8a
         with:
-          images: ghcr.io/${{ github.repository_owner }}/ahnlich-mcp
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ needs.release_metadata.outputs.mcp_version }}
             type=raw,value=latest
-          labels: |
-            org.opencontainers.image.title=Ahnlich MCP
-            org.opencontainers.image.description=MCP server for Ahnlich vector storage and semantic search
-            org.opencontainers.image.version=${{ needs.release_metadata.outputs.mcp_version }}
 
-      - name: Build and push image
-        id: push
+      - name: Build and publish container
+        id: build
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85
         with:
           context: ./mcp
-          push: true
+          file: ./mcp/Dockerfile
           platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=gha,scope=ahnlich-mcp
-          cache-to: type=gha,mode=max,scope=ahnlich-mcp
 
-      - name: Generate image attestation
+      - name: Attest container provenance
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/ahnlich-mcp
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true


### PR DESCRIPTION
- Updates MCP release workflow to run after merging to main. 
- Adds manual triggering, release-tag checks, safe retries, and publishes MCP packages to PyPI and GHCR.