### PR TITLE
perf(db): optimize predicate index operations

### DIFF
--- a/.github/workflows/benchmark-experiments.yml
+++ b/.github/workflows/benchmark-experiments.yml
@@ -100,6 +100,7 @@ jobs:
           cargo bench \
             --manifest-path "ahnlich/${crate}/Cargo.toml" \
             --bench "$target" \
+            --features bench-experiments \
             -- \
             --save-baseline "$baseline"
         done < "$RUNNER_TEMP/benchmark-targets.tsv"
@@ -120,6 +121,7 @@ jobs:
           cargo bench \
             --manifest-path "ahnlich/${crate}/Cargo.toml" \
             --bench "$target" \
+            --features bench-experiments \
             -- \
             --save-baseline "$baseline"
         done < "$RUNNER_TEMP/benchmark-targets.tsv"

--- a/ahnlich/db/Cargo.toml
+++ b/ahnlich/db/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 default = ["server"]
+bench-experiments = []
 server = [
     "dep:tonic",
     "dep:prost",
@@ -89,3 +90,21 @@ harness = false
 name = "papaya_linear_search"
 path = "benches/experiments/papaya_linear_search.rs"
 harness = false
+
+[[bench]]
+name = "predicate_in_lookup"
+path = "benches/experiments/predicate_in_lookup.rs"
+harness = false
+required-features = ["bench-experiments"]
+
+[[bench]]
+name = "predicate_index_deletion"
+path = "benches/experiments/predicate_index_deletion.rs"
+harness = false
+required-features = ["bench-experiments"]
+
+[[bench]]
+name = "predicate_empty_index_ingestion"
+path = "benches/experiments/predicate_empty_index_ingestion.rs"
+harness = false
+required-features = ["bench-experiments"]

--- a/ahnlich/db/benches/experiments/predicate_empty_index_ingestion.rs
+++ b/ahnlich/db/benches/experiments/predicate_empty_index_ingestion.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ahnlich_db::engine::predicate::benchmark::EmptyPredicateIngestionBenchmark;
+use ahnlich_types::keyval::StoreValue;
+use ahnlich_types::metadata::{MetadataValue, metadata_value};
+use ahnlich_types::utils::StoreKeyId;
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+const BATCH_SIZES: [usize; 4] = [100, 1_000, 10_000, 100_000];
+const METADATA_FIELD_COUNTS: [usize; 3] = [0, 4, 16];
+
+#[derive(Clone, Copy)]
+enum MetadataFilteringPolicy {
+    Sequential,
+    Adaptive,
+}
+
+impl MetadataFilteringPolicy {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Sequential => "sequential_filtering",
+            Self::Adaptive => "adaptive_filtering",
+        }
+    }
+
+    const fn threshold(self) -> usize {
+        match self {
+            Self::Sequential => usize::MAX,
+            Self::Adaptive => 10_000,
+        }
+    }
+}
+
+fn metadata_value(entry_index: usize, field_index: usize) -> MetadataValue {
+    MetadataValue {
+        value: Some(metadata_value::Value::RawString(format!(
+            "value-{}",
+            (entry_index + field_index) % 100
+        ))),
+    }
+}
+
+fn entries(batch_size: usize, metadata_field_count: usize) -> Vec<(StoreKeyId, Arc<StoreValue>)> {
+    (0..batch_size)
+        .map(|entry_index| {
+            let metadata = (0..metadata_field_count)
+                .map(|field_index| {
+                    (
+                        format!("unindexed-{field_index}"),
+                        metadata_value(entry_index, field_index),
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+
+            (
+                StoreKeyId(entry_index as u64),
+                Arc::new(StoreValue { value: metadata }),
+            )
+        })
+        .collect()
+}
+
+fn predicate_empty_index_ingestion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("predicate_empty_index_ingestion");
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    for batch_size in BATCH_SIZES {
+        for metadata_field_count in METADATA_FIELD_COUNTS {
+            for policy in [
+                MetadataFilteringPolicy::Sequential,
+                MetadataFilteringPolicy::Adaptive,
+            ] {
+                let benchmark = EmptyPredicateIngestionBenchmark::new(
+                    entries(batch_size, metadata_field_count),
+                    policy.threshold(),
+                );
+                let scenario = format!(
+                    "{}_entries_{}_metadata_fields_{}",
+                    batch_size,
+                    metadata_field_count,
+                    policy.label()
+                );
+
+                benchmark.run_control();
+                assert_eq!(benchmark.indexed_key_count(), 0);
+                benchmark.run_candidate();
+                assert_eq!(benchmark.indexed_key_count(), 0);
+
+                group.throughput(Throughput::Elements(batch_size as u64));
+                group.bench_with_input(
+                    BenchmarkId::new("control", &scenario),
+                    &benchmark,
+                    |b, benchmark| {
+                        b.iter(|| benchmark.run_control());
+                    },
+                );
+                group.bench_with_input(
+                    BenchmarkId::new("candidate", &scenario),
+                    &benchmark,
+                    |b, benchmark| {
+                        b.iter(|| black_box(benchmark).run_candidate());
+                    },
+                );
+            }
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3));
+    targets = predicate_empty_index_ingestion
+}
+criterion_main!(benches);

--- a/ahnlich/db/benches/experiments/predicate_empty_index_ingestion.rs
+++ b/ahnlich/db/benches/experiments/predicate_empty_index_ingestion.rs
@@ -2,14 +2,109 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ahnlich_db::engine::predicate::benchmark::EmptyPredicateIngestionBenchmark;
+use ahnlich_db::engine::store::ParallelismConfig;
 use ahnlich_types::keyval::StoreValue;
 use ahnlich_types::metadata::{MetadataValue, metadata_value};
 use ahnlich_types::utils::StoreKeyId;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use papaya::HashSet as ConcurrentHashSet;
+use rayon::prelude::*;
 
 const BATCH_SIZES: [usize; 4] = [100, 1_000, 10_000, 100_000];
 const METADATA_FIELD_COUNTS: [usize; 3] = [0, 4, 16];
+
+struct EmptyPredicateIngestionBenchmark {
+    allowed_predicates: ConcurrentHashSet<String>,
+    entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
+    parallelism_config: ParallelismConfig,
+}
+
+impl EmptyPredicateIngestionBenchmark {
+    fn new(
+        entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
+        metadata_filtering_threshold: usize,
+    ) -> Self {
+        Self {
+            allowed_predicates: ConcurrentHashSet::with_capacity(1),
+            entries,
+            parallelism_config: ParallelismConfig::from_cli(
+                rayon::current_num_threads(),
+                None,
+                metadata_filtering_threshold,
+            ),
+        }
+    }
+
+    fn stage_entries(&self) -> Vec<(StoreKeyId, Arc<StoreValue>)> {
+        self.entries
+            .par_iter()
+            .map(|(store_key_id, store_value)| (*store_key_id, Arc::clone(store_value)))
+            .collect()
+    }
+
+    fn filter_metadata(&self, entries: Vec<(StoreKeyId, Arc<StoreValue>)>) {
+        let use_parallel = self
+            .parallelism_config
+            .should_use_parallel(entries.len(), 1);
+
+        let _: HashMap<String, Vec<(MetadataValue, StoreKeyId)>> = if use_parallel {
+            entries
+                .into_par_iter()
+                .flat_map(|(store_key_id, store_value)| {
+                    Arc::clone(&store_value).value.clone().into_par_iter().map(
+                        move |(key, value)| {
+                            let allowed_predicates = self.allowed_predicates.pin();
+                            allowed_predicates
+                                .contains(&key)
+                                .then_some((store_key_id, key, value))
+                        },
+                    )
+                })
+                .flatten()
+                .map(|(store_key_id, key, value)| (key, (value, store_key_id)))
+                .fold(HashMap::new, |mut grouped, (key, value)| {
+                    grouped.entry(key).or_default().push(value);
+                    grouped
+                })
+                .reduce(HashMap::new, |mut grouped, values| {
+                    for (key, mut value) in values {
+                        grouped.entry(key).or_default().append(&mut value);
+                    }
+                    grouped
+                })
+        } else {
+            let mut grouped = HashMap::new();
+            for (store_key_id, store_value) in entries {
+                let allowed_predicates = self.allowed_predicates.pin();
+                for (key, value) in &store_value.value {
+                    if allowed_predicates.contains(key) {
+                        grouped
+                            .entry(key.clone())
+                            .or_insert_with(Vec::new)
+                            .push((value.clone(), store_key_id));
+                    }
+                }
+            }
+            grouped
+        };
+    }
+
+    fn run_control(&self) {
+        self.filter_metadata(self.stage_entries());
+    }
+
+    fn run_candidate(&self) {
+        if self.allowed_predicates.is_empty() {
+            return;
+        }
+
+        self.filter_metadata(self.stage_entries());
+    }
+
+    fn indexed_key_count(&self) -> usize {
+        self.allowed_predicates.len()
+    }
+}
 
 #[derive(Clone, Copy)]
 enum MetadataFilteringPolicy {

--- a/ahnlich/db/benches/experiments/predicate_empty_index_ingestion.rs
+++ b/ahnlich/db/benches/experiments/predicate_empty_index_ingestion.rs
@@ -62,10 +62,14 @@ impl EmptyPredicateIngestionBenchmark {
                 })
                 .flatten()
                 .map(|(store_key_id, key, value)| (key, (value, store_key_id)))
-                .fold(HashMap::new, |mut grouped, (key, value)| {
-                    grouped.entry(key).or_default().push(value);
-                    grouped
-                })
+                .fold(
+                    HashMap::new,
+                    |mut grouped: HashMap<String, Vec<(MetadataValue, StoreKeyId)>>,
+                     (key, value)| {
+                        grouped.entry(key).or_default().push(value);
+                        grouped
+                    },
+                )
                 .reduce(HashMap::new, |mut grouped, values| {
                     for (key, mut value) in values {
                         grouped.entry(key).or_default().append(&mut value);
@@ -73,14 +77,14 @@ impl EmptyPredicateIngestionBenchmark {
                     grouped
                 })
         } else {
-            let mut grouped = HashMap::new();
+            let mut grouped: HashMap<String, Vec<(MetadataValue, StoreKeyId)>> = HashMap::new();
             for (store_key_id, store_value) in entries {
                 let allowed_predicates = self.allowed_predicates.pin();
                 for (key, value) in &store_value.value {
                     if allowed_predicates.contains(key) {
                         grouped
                             .entry(key.clone())
-                            .or_insert_with(Vec::new)
+                            .or_default()
                             .push((value.clone(), store_key_id));
                     }
                 }

--- a/ahnlich/db/benches/experiments/predicate_in_lookup.rs
+++ b/ahnlich/db/benches/experiments/predicate_in_lookup.rs
@@ -1,0 +1,167 @@
+use std::time::Duration;
+
+use ahnlich_db::engine::predicate::benchmark::PredicateInLookupBenchmark;
+use ahnlich_types::metadata::{MetadataValue, metadata_value};
+use ahnlich_types::predicates::{In, Predicate, predicate::Kind as PredicateKind};
+use ahnlich_types::utils::StoreKeyId;
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+
+const INDEX_CARDINALITIES: [usize; 3] = [100, 1_000, 100_000];
+const REQUESTED_VALUE_COUNTS: [usize; 3] = [1, 4, 32];
+const IDS_PER_VALUE: [usize; 2] = [1, 32];
+const DUPLICATE_VALUE_COUNTS: [usize; 2] = [4, 32];
+
+#[derive(Clone, Copy)]
+enum MatchPattern {
+    Hits,
+    Misses,
+    Mixed,
+}
+
+impl MatchPattern {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Hits => "hits",
+            Self::Misses => "misses",
+            Self::Mixed => "mixed",
+        }
+    }
+}
+
+fn metadata_value(index: usize) -> MetadataValue {
+    MetadataValue {
+        value: Some(metadata_value::Value::RawString(format!("value-{index}"))),
+    }
+}
+
+fn missing_metadata_value(index: usize) -> MetadataValue {
+    MetadataValue {
+        value: Some(metadata_value::Value::RawString(format!(
+            "missing-value-{index}"
+        ))),
+    }
+}
+
+fn fixture(cardinality: usize, ids_per_value: usize) -> PredicateInLookupBenchmark {
+    let entries = (0..cardinality)
+        .flat_map(|value_index| {
+            let value = metadata_value(value_index);
+            (0..ids_per_value).map(move |id_index| {
+                let store_key_id = value_index * ids_per_value + id_index;
+                (value.clone(), StoreKeyId(store_key_id as u64))
+            })
+        })
+        .collect();
+
+    PredicateInLookupBenchmark::new(entries)
+}
+
+fn requested_values(
+    cardinality: usize,
+    requested_count: usize,
+    pattern: MatchPattern,
+) -> Vec<MetadataValue> {
+    (0..requested_count)
+        .map(|index| match pattern {
+            MatchPattern::Hits => metadata_value(index * cardinality / requested_count),
+            MatchPattern::Misses => missing_metadata_value(index),
+            MatchPattern::Mixed if index % 2 == 0 => {
+                metadata_value(index * cardinality / requested_count)
+            }
+            MatchPattern::Mixed => missing_metadata_value(index),
+        })
+        .collect()
+}
+
+fn in_predicate(values: Vec<MetadataValue>) -> Predicate {
+    Predicate {
+        kind: Some(PredicateKind::In(In {
+            key: "indexed-field".to_string(),
+            values,
+        })),
+    }
+}
+
+fn benchmark_scenario(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    fixture: &PredicateInLookupBenchmark,
+    scenario: &str,
+    predicate: &Predicate,
+) {
+    assert_eq!(
+        fixture.matches_control(predicate),
+        fixture.matches_candidate(predicate),
+        "control and candidate differed for {scenario}"
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("control", scenario),
+        predicate,
+        |b, predicate| {
+            b.iter(|| black_box(fixture.matches_control(black_box(predicate))));
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("candidate", scenario),
+        predicate,
+        |b, predicate| {
+            b.iter(|| black_box(fixture.matches_candidate(black_box(predicate))));
+        },
+    );
+}
+
+fn predicate_in_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("predicate_in_lookup");
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    for cardinality in INDEX_CARDINALITIES {
+        for ids_per_value in IDS_PER_VALUE {
+            let fixture = fixture(cardinality, ids_per_value);
+
+            for requested_count in REQUESTED_VALUE_COUNTS {
+                for pattern in [
+                    MatchPattern::Hits,
+                    MatchPattern::Misses,
+                    MatchPattern::Mixed,
+                ] {
+                    if requested_count == 1 && matches!(pattern, MatchPattern::Mixed) {
+                        continue;
+                    }
+
+                    let scenario = format!(
+                        "{}_cardinality_{}_requested_{}_{}_ids_per_value",
+                        cardinality,
+                        requested_count,
+                        pattern.label(),
+                        ids_per_value
+                    );
+                    let predicate =
+                        in_predicate(requested_values(cardinality, requested_count, pattern));
+                    benchmark_scenario(&mut group, &fixture, &scenario, &predicate);
+                }
+            }
+
+            for duplicate_count in DUPLICATE_VALUE_COUNTS {
+                let scenario = format!(
+                    "{}_cardinality_{}_duplicate_hits_{}_ids_per_value",
+                    cardinality, duplicate_count, ids_per_value
+                );
+                let predicate = in_predicate(vec![metadata_value(0); duplicate_count]);
+                benchmark_scenario(&mut group, &fixture, &scenario, &predicate);
+            }
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3));
+    targets = predicate_in_lookup
+}
+criterion_main!(benches);

--- a/ahnlich/db/benches/experiments/predicate_in_lookup.rs
+++ b/ahnlich/db/benches/experiments/predicate_in_lookup.rs
@@ -1,15 +1,76 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
-use ahnlich_db::engine::predicate::benchmark::PredicateInLookupBenchmark;
 use ahnlich_types::metadata::{MetadataValue, metadata_value};
 use ahnlich_types::predicates::{In, Predicate, predicate::Kind as PredicateKind};
 use ahnlich_types::utils::StoreKeyId;
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use papaya::{HashMap as ConcurrentHashMap, HashSet as ConcurrentHashSet};
 
 const INDEX_CARDINALITIES: [usize; 3] = [100, 1_000, 100_000];
 const REQUESTED_VALUE_COUNTS: [usize; 3] = [1, 4, 32];
 const IDS_PER_VALUE: [usize; 2] = [1, 32];
 const DUPLICATE_VALUE_COUNTS: [usize; 2] = [4, 32];
+
+struct PredicateInLookupBenchmark {
+    buckets: ConcurrentHashMap<MetadataValue, ConcurrentHashSet<StoreKeyId>>,
+}
+
+impl PredicateInLookupBenchmark {
+    fn new(entries: Vec<(MetadataValue, StoreKeyId)>) -> Self {
+        let buckets = ConcurrentHashMap::with_capacity(1);
+        let pinned = buckets.pin();
+
+        for (metadata_value, store_key_id) in entries {
+            if let Some(store_key_ids) = pinned.get(&metadata_value) {
+                store_key_ids.pin().insert(store_key_id);
+            } else {
+                let store_key_ids = ConcurrentHashSet::with_capacity(1);
+                store_key_ids.pin().insert(store_key_id);
+                if let Err(existing) = pinned.try_insert(metadata_value, store_key_ids) {
+                    existing.current.pin().insert(store_key_id);
+                }
+            }
+        }
+        drop(pinned);
+
+        Self { buckets }
+    }
+
+    fn matches_control(&self, predicate: &Predicate) -> HashSet<StoreKeyId> {
+        let Predicate {
+            kind: Some(PredicateKind::In(In { values, .. })),
+        } = predicate
+        else {
+            unreachable!("In lookup benchmark requires an In predicate");
+        };
+        let buckets = self.buckets.pin();
+
+        buckets
+            .iter()
+            .filter(|(metadata_value, _)| values.contains(metadata_value))
+            .flat_map(|(_, store_key_ids)| store_key_ids.pin().iter().copied().collect::<Vec<_>>())
+            .collect()
+    }
+
+    fn matches_candidate(&self, predicate: &Predicate) -> HashSet<StoreKeyId> {
+        let Predicate {
+            kind: Some(PredicateKind::In(In { values, .. })),
+        } = predicate
+        else {
+            unreachable!("In lookup benchmark requires an In predicate");
+        };
+        let buckets = self.buckets.pin();
+        let mut matches = HashSet::new();
+
+        for value in values {
+            if let Some(store_key_ids) = buckets.get(value) {
+                matches.extend(store_key_ids.pin().iter().copied());
+            }
+        }
+        matches
+    }
+}
 
 #[derive(Clone, Copy)]
 enum MatchPattern {

--- a/ahnlich/db/benches/experiments/predicate_in_lookup.rs
+++ b/ahnlich/db/benches/experiments/predicate_in_lookup.rs
@@ -18,7 +18,8 @@ struct PredicateInLookupBenchmark {
 
 impl PredicateInLookupBenchmark {
     fn new(entries: Vec<(MetadataValue, StoreKeyId)>) -> Self {
-        let buckets = ConcurrentHashMap::with_capacity(1);
+        let buckets: ConcurrentHashMap<MetadataValue, ConcurrentHashSet<StoreKeyId>> =
+            ConcurrentHashMap::with_capacity(1);
         let pinned = buckets.pin();
 
         for (metadata_value, store_key_id) in entries {

--- a/ahnlich/db/benches/experiments/predicate_index_deletion.rs
+++ b/ahnlich/db/benches/experiments/predicate_index_deletion.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ahnlich_db::engine::predicate::benchmark::PredicateDeletionBenchmark;
+use ahnlich_types::keyval::StoreValue;
+use ahnlich_types::metadata::{MetadataValue, metadata_value};
+use ahnlich_types::utils::StoreKeyId;
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
+#[derive(Clone, Copy)]
+struct Scenario {
+    name: &'static str,
+    entry_count: usize,
+    indexed_key_count: usize,
+    unindexed_key_count: usize,
+    cardinality: usize,
+    delete_count: usize,
+}
+
+const SCENARIOS: [Scenario; 6] = [
+    Scenario {
+        name: "low_cardinality_sparse_delete",
+        entry_count: 10_000,
+        indexed_key_count: 4,
+        unindexed_key_count: 0,
+        cardinality: 100,
+        delete_count: 1,
+    },
+    Scenario {
+        name: "high_cardinality_sparse_delete",
+        entry_count: 100_000,
+        indexed_key_count: 4,
+        unindexed_key_count: 0,
+        cardinality: 100_000,
+        delete_count: 1,
+    },
+    Scenario {
+        name: "high_cardinality_batch_delete",
+        entry_count: 100_000,
+        indexed_key_count: 4,
+        unindexed_key_count: 0,
+        cardinality: 100_000,
+        delete_count: 100,
+    },
+    Scenario {
+        name: "low_cardinality_dense_delete",
+        entry_count: 100_000,
+        indexed_key_count: 4,
+        unindexed_key_count: 0,
+        cardinality: 100,
+        delete_count: 10_000,
+    },
+    Scenario {
+        name: "many_predicate_indexes",
+        entry_count: 50_000,
+        indexed_key_count: 8,
+        unindexed_key_count: 0,
+        cardinality: 10_000,
+        delete_count: 100,
+    },
+    Scenario {
+        name: "wide_metadata",
+        entry_count: 50_000,
+        indexed_key_count: 4,
+        unindexed_key_count: 12,
+        cardinality: 10_000,
+        delete_count: 100,
+    },
+];
+
+fn metadata_value(value_index: usize) -> MetadataValue {
+    MetadataValue {
+        value: Some(metadata_value::Value::RawString(format!(
+            "value-{value_index}"
+        ))),
+    }
+}
+
+fn fixture(scenario: Scenario) -> PredicateDeletionBenchmark {
+    let indexed_keys = (0..scenario.indexed_key_count)
+        .map(|index| format!("indexed-{index}"))
+        .collect::<Vec<_>>();
+
+    let entries = (0..scenario.entry_count)
+        .map(|entry_index| {
+            let mut metadata =
+                HashMap::with_capacity(scenario.indexed_key_count + scenario.unindexed_key_count);
+
+            for key_index in 0..scenario.indexed_key_count {
+                metadata.insert(
+                    format!("indexed-{key_index}"),
+                    metadata_value((entry_index + key_index) % scenario.cardinality),
+                );
+            }
+            for key_index in 0..scenario.unindexed_key_count {
+                metadata.insert(
+                    format!("unindexed-{key_index}"),
+                    metadata_value((entry_index + key_index) % scenario.cardinality),
+                );
+            }
+
+            (
+                StoreKeyId(entry_index as u64),
+                Arc::new(StoreValue { value: metadata }),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let removed = (0..scenario.delete_count)
+        .map(|delete_index| {
+            let entry_index = delete_index * scenario.entry_count / scenario.delete_count;
+            entries[entry_index].clone()
+        })
+        .collect();
+
+    PredicateDeletionBenchmark::new(indexed_keys, entries, removed)
+}
+
+fn assert_equivalent(scenario: Scenario) {
+    let control = fixture(scenario);
+    control.remove_control();
+
+    let candidate = fixture(scenario);
+    candidate.remove_candidate();
+
+    assert_eq!(
+        control.snapshot(),
+        candidate.snapshot(),
+        "control and candidate differed for {}",
+        scenario.name
+    );
+}
+
+fn measure_repeated_deletion(
+    benchmark: &PredicateDeletionBenchmark,
+    iterations: u64,
+    delete: impl Fn(&PredicateDeletionBenchmark),
+) -> Duration {
+    let mut measured = Duration::ZERO;
+    for _ in 0..iterations {
+        let start = Instant::now();
+        delete(benchmark);
+        measured += start.elapsed();
+
+        // Restoration is deliberately excluded from deletion latency.
+        benchmark.restore_removed();
+    }
+    measured
+}
+
+fn predicate_index_deletion(c: &mut Criterion) {
+    let mut group = c.benchmark_group("predicate_index_deletion");
+    group.sampling_mode(criterion::SamplingMode::Flat);
+
+    for scenario in SCENARIOS {
+        assert_equivalent(scenario);
+
+        group.bench_function(BenchmarkId::new("control", scenario.name), |b| {
+            let benchmark = fixture(scenario);
+            b.iter_custom(|iterations| {
+                measure_repeated_deletion(&benchmark, iterations, |benchmark| {
+                    benchmark.remove_control();
+                })
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("candidate", scenario.name), |b| {
+            let benchmark = fixture(scenario);
+            b.iter_custom(|iterations| {
+                measure_repeated_deletion(&benchmark, iterations, |benchmark| {
+                    benchmark.remove_candidate();
+                })
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(3));
+    targets = predicate_index_deletion
+}
+criterion_main!(benches);

--- a/ahnlich/db/benches/experiments/predicate_index_deletion.rs
+++ b/ahnlich/db/benches/experiments/predicate_index_deletion.rs
@@ -1,12 +1,146 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use ahnlich_db::engine::predicate::benchmark::PredicateDeletionBenchmark;
 use ahnlich_types::keyval::StoreValue;
 use ahnlich_types::metadata::{MetadataValue, metadata_value};
 use ahnlich_types::utils::StoreKeyId;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use papaya::{HashMap as ConcurrentHashMap, HashSet as ConcurrentHashSet};
+
+type PredicateIndexSnapshot = HashMap<String, HashMap<MetadataValue, HashSet<StoreKeyId>>>;
+
+struct BenchmarkPredicateIndex {
+    buckets: ConcurrentHashMap<MetadataValue, ConcurrentHashSet<StoreKeyId>>,
+}
+
+impl BenchmarkPredicateIndex {
+    fn new() -> Self {
+        Self {
+            buckets: ConcurrentHashMap::with_capacity(1),
+        }
+    }
+
+    fn add(&self, metadata_value: MetadataValue, store_key_id: StoreKeyId) {
+        let buckets = self.buckets.pin();
+        if let Some(store_key_ids) = buckets.get(&metadata_value) {
+            store_key_ids.pin().insert(store_key_id);
+        } else {
+            let store_key_ids = ConcurrentHashSet::with_capacity(1);
+            store_key_ids.pin().insert(store_key_id);
+            if let Err(existing) = buckets.try_insert(metadata_value, store_key_ids) {
+                existing.current.pin().insert(store_key_id);
+            }
+        }
+    }
+
+    fn remove_store_keys(&self, remove_keys: &[StoreKeyId]) {
+        let buckets = self.buckets.pin();
+        for (_, store_key_ids) in buckets.iter() {
+            let store_key_ids = store_key_ids.pin();
+            for store_key_id in remove_keys {
+                store_key_ids.remove(store_key_id);
+            }
+        }
+    }
+
+    fn remove_store_key(&self, metadata_value: &MetadataValue, store_key_id: &StoreKeyId) {
+        let buckets = self.buckets.pin();
+        if let Some(store_key_ids) = buckets.get(metadata_value) {
+            store_key_ids.pin().remove(store_key_id);
+        }
+    }
+}
+
+struct PredicateDeletionBenchmark {
+    indices: ConcurrentHashMap<String, BenchmarkPredicateIndex>,
+    removed: Vec<(StoreKeyId, Arc<StoreValue>)>,
+    removed_keys: Vec<StoreKeyId>,
+}
+
+impl PredicateDeletionBenchmark {
+    fn new(
+        indexed_keys: Vec<String>,
+        entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
+        removed: Vec<(StoreKeyId, Arc<StoreValue>)>,
+    ) -> Self {
+        let indices = ConcurrentHashMap::with_capacity(1);
+        let pinned = indices.pin();
+        for key in indexed_keys {
+            pinned.insert(key, BenchmarkPredicateIndex::new());
+        }
+        drop(pinned);
+
+        let benchmark = Self {
+            indices,
+            removed_keys: removed
+                .iter()
+                .map(|(store_key_id, _)| *store_key_id)
+                .collect(),
+            removed,
+        };
+        benchmark.add(
+            entries
+                .iter()
+                .map(|(store_key_id, store_value)| (*store_key_id, store_value.as_ref())),
+        );
+        benchmark
+    }
+
+    fn add<'a>(&self, entries: impl IntoIterator<Item = (StoreKeyId, &'a StoreValue)>) {
+        let indices = self.indices.pin();
+        for (store_key_id, store_value) in entries {
+            for (metadata_key, metadata_value) in &store_value.value {
+                if let Some(index) = indices.get(metadata_key) {
+                    index.add(metadata_value.clone(), store_key_id);
+                }
+            }
+        }
+    }
+
+    fn remove_control(&self) {
+        let indices = self.indices.pin();
+        for (_, index) in indices.iter() {
+            index.remove_store_keys(&self.removed_keys);
+        }
+    }
+
+    fn remove_candidate(&self) {
+        let indices = self.indices.pin();
+        for (store_key_id, store_value) in &self.removed {
+            for (metadata_key, metadata_value) in &store_value.value {
+                if let Some(index) = indices.get(metadata_key) {
+                    index.remove_store_key(metadata_value, store_key_id);
+                }
+            }
+        }
+    }
+
+    fn restore_removed(&self) {
+        self.add(
+            self.removed
+                .iter()
+                .map(|(store_key_id, store_value)| (*store_key_id, store_value.as_ref())),
+        );
+    }
+
+    fn snapshot(&self) -> PredicateIndexSnapshot {
+        let indices = self.indices.pin();
+        indices
+            .iter()
+            .map(|(key, index)| {
+                let buckets = index.buckets.pin();
+                let values = buckets
+                    .iter()
+                    .map(|(value, store_key_ids)| {
+                        (value.clone(), store_key_ids.pin().iter().copied().collect())
+                    })
+                    .collect();
+                (key.clone(), values)
+            })
+            .collect()
+    }
+}
 
 #[derive(Clone, Copy)]
 struct Scenario {

--- a/ahnlich/db/src/engine/mod.rs
+++ b/ahnlich/db/src/engine/mod.rs
@@ -1,4 +1,7 @@
 pub mod operations;
+#[cfg(feature = "bench-experiments")]
+pub mod predicate;
+#[cfg(not(feature = "bench-experiments"))]
 pub(crate) mod predicate;
 pub mod store;
 pub mod versioned;

--- a/ahnlich/db/src/engine/mod.rs
+++ b/ahnlich/db/src/engine/mod.rs
@@ -1,7 +1,4 @@
 pub mod operations;
-#[cfg(feature = "bench-experiments")]
-pub mod predicate;
-#[cfg(not(feature = "bench-experiments"))]
 pub(crate) mod predicate;
 pub mod store;
 pub mod versioned;

--- a/ahnlich/db/src/engine/predicate.rs
+++ b/ahnlich/db/src/engine/predicate.rs
@@ -163,11 +163,28 @@ impl PredicateIndices {
     }
 
     /// Removes a store key id when it's corresponding entry in the store is removed
+    #[cfg(feature = "bench-experiments")]
     #[tracing::instrument(skip(self))]
     pub(super) fn remove_store_keys(&self, remove_keys: &[StoreKeyId]) {
         let pinned = self.inner.pin();
         for (_, values) in pinned.iter() {
             values.remove_store_keys(remove_keys);
+        }
+    }
+
+    /// Removes each store key id from the predicate buckets described by its stored metadata.
+    #[tracing::instrument(skip_all)]
+    pub(super) fn remove_store_entries<'a>(
+        &self,
+        removed: impl IntoIterator<Item = (StoreKeyId, &'a StoreValue)>,
+    ) {
+        let indices = self.inner.pin();
+        for (store_key_id, store_value) in removed {
+            for (metadata_key, metadata_value) in &store_value.value {
+                if let Some(index) = indices.get(metadata_key) {
+                    index.remove_store_key(metadata_value, &store_key_id);
+                }
+            }
         }
     }
 
@@ -409,6 +426,7 @@ impl PredicateIndex {
     }
 
     /// Removes a store key id when it's corresponding entry in the store is removed
+    #[cfg(any(test, feature = "bench-experiments"))]
     #[tracing::instrument(skip(self))]
     fn remove_store_keys(&self, remove_keys: &[StoreKeyId]) {
         let inner = self.0.pin();
@@ -417,6 +435,13 @@ impl PredicateIndex {
             for k in remove_keys {
                 values_pinned.remove(k);
             }
+        }
+    }
+
+    fn remove_store_key(&self, metadata_value: &MetadataValue, store_key_id: &StoreKeyId) {
+        let buckets = self.0.pin();
+        if let Some(store_key_ids) = buckets.get(metadata_value) {
+            store_key_ids.pin().remove(store_key_id);
         }
     }
 
@@ -504,11 +529,15 @@ impl PredicateIndex {
                 .collect(),
             Predicate {
                 kind: Some(PredicateKind::In(predicates::In { values, .. })),
-            } => pinned
-                .iter()
-                .filter(|(key, _)| values.contains(key))
-                .flat_map(|(_, value)| value.pin().iter().cloned().collect::<Vec<_>>())
-                .collect(),
+            } => {
+                let mut matches = StdHashSet::new();
+                for value in values {
+                    if let Some(store_key_ids) = pinned.get(value) {
+                        matches.extend(store_key_ids.pin().iter().copied());
+                    }
+                }
+                matches
+            }
 
             Predicate {
                 kind: Some(PredicateKind::NotIn(predicates::NotIn { values, .. })),
@@ -519,6 +548,163 @@ impl PredicateIndex {
                 .collect(),
 
             Predicate { kind: None } => unreachable!(),
+        }
+    }
+
+    #[cfg(feature = "bench-experiments")]
+    #[tracing::instrument(skip(self))]
+    fn matches_in_scan_bench(&self, predicate: &Predicate) -> StdHashSet<StoreKeyId> {
+        let pinned = self.0.pin();
+        match predicate {
+            Predicate {
+                kind: Some(PredicateKind::In(predicates::In { values, .. })),
+            } => pinned
+                .iter()
+                .filter(|(key, _)| values.contains(key))
+                .flat_map(|(_, value)| value.pin().iter().cloned().collect::<Vec<_>>())
+                .collect(),
+            _ => unreachable!("In scan benchmark requires an In predicate"),
+        }
+    }
+}
+
+#[cfg(feature = "bench-experiments")]
+pub mod benchmark {
+    use super::*;
+
+    pub struct PredicateInLookupBenchmark(PredicateIndex);
+
+    impl PredicateInLookupBenchmark {
+        pub fn new(entries: Vec<(MetadataValue, StoreKeyId)>) -> Self {
+            let config = super::super::store::ParallelismConfig::from_cli(1, None, usize::MAX);
+            Self(PredicateIndex::init(entries, &config, 1))
+        }
+
+        pub fn matches_control(&self, predicate: &Predicate) -> StdHashSet<StoreKeyId> {
+            self.0.matches_in_scan_bench(predicate)
+        }
+
+        pub fn matches_candidate(&self, predicate: &Predicate) -> StdHashSet<StoreKeyId> {
+            self.0.matches(predicate)
+        }
+    }
+
+    pub type PredicateIndexSnapshot =
+        HashMap<String, HashMap<MetadataValue, StdHashSet<StoreKeyId>>>;
+
+    pub struct PredicateDeletionBenchmark {
+        indices: PredicateIndices,
+        removed: Vec<(StoreKeyId, Arc<StoreValue>)>,
+        removed_keys: Vec<StoreKeyId>,
+        parallelism_config: super::super::store::ParallelismConfig,
+    }
+
+    impl PredicateDeletionBenchmark {
+        pub fn new(
+            indexed_keys: Vec<String>,
+            entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
+            removed: Vec<(StoreKeyId, Arc<StoreValue>)>,
+        ) -> Self {
+            let parallelism_config =
+                super::super::store::ParallelismConfig::from_cli(1, None, usize::MAX);
+            let indices = PredicateIndices::init(indexed_keys);
+            indices.add(entries, &parallelism_config, 1);
+            let removed_keys = removed
+                .iter()
+                .map(|(store_key_id, _)| *store_key_id)
+                .collect();
+
+            Self {
+                indices,
+                removed,
+                removed_keys,
+                parallelism_config,
+            }
+        }
+
+        pub fn remove_control(&self) {
+            self.indices.remove_store_keys(&self.removed_keys);
+        }
+
+        pub fn remove_candidate(&self) {
+            self.indices.remove_store_entries(
+                self.removed
+                    .iter()
+                    .map(|(store_key_id, store_value)| (*store_key_id, store_value.as_ref())),
+            );
+        }
+
+        pub fn restore_removed(&self) {
+            self.indices
+                .add(self.removed.clone(), &self.parallelism_config, 1);
+        }
+
+        pub fn snapshot(&self) -> PredicateIndexSnapshot {
+            let indices = self.indices.inner.pin();
+            indices
+                .iter()
+                .map(|(key, index)| {
+                    let buckets = index.0.pin();
+                    let values = buckets
+                        .iter()
+                        .map(|(value, store_key_ids)| {
+                            (value.clone(), store_key_ids.pin().iter().copied().collect())
+                        })
+                        .collect();
+                    (key.clone(), values)
+                })
+                .collect()
+        }
+    }
+
+    pub struct EmptyPredicateIngestionBenchmark {
+        indices: PredicateIndices,
+        entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
+        parallelism_config: super::super::store::ParallelismConfig,
+    }
+
+    impl EmptyPredicateIngestionBenchmark {
+        pub fn new(
+            entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
+            metadata_filtering_threshold: usize,
+        ) -> Self {
+            Self {
+                indices: PredicateIndices::init(Vec::new()),
+                entries,
+                parallelism_config: super::super::store::ParallelismConfig::from_cli(
+                    rayon::current_num_threads(),
+                    None,
+                    metadata_filtering_threshold,
+                ),
+            }
+        }
+
+        pub fn run_control(&self) {
+            let predicate_insert = self
+                .entries
+                .par_iter()
+                .map(|(store_key_id, store_value)| (*store_key_id, Arc::clone(store_value)))
+                .collect();
+            self.indices
+                .add(predicate_insert, &self.parallelism_config, 1);
+        }
+
+        pub fn run_candidate(&self) {
+            if self.indices.is_empty() {
+                return;
+            }
+
+            let predicate_insert = self
+                .entries
+                .par_iter()
+                .map(|(store_key_id, store_value)| (*store_key_id, Arc::clone(store_value)))
+                .collect();
+            self.indices
+                .add(predicate_insert, &self.parallelism_config, 1);
+        }
+
+        pub fn indexed_key_count(&self) -> usize {
+            self.indices.current_predicates().len()
         }
     }
 }
@@ -934,7 +1120,15 @@ mod tests {
         assert_eq!(result, StdHashSet::from_iter([StoreKeyId(1)]));
         // remove all Nigerians from the predicate and check that conditions working before no
         // longer work and those working before still work
-        shared_pred.remove_store_keys(&[StoreKeyId(0), StoreKeyId(2)]);
+        let removed = [
+            (StoreKeyId(0), store_value_0()),
+            (StoreKeyId(2), store_value_2()),
+        ];
+        shared_pred.remove_store_entries(
+            removed
+                .iter()
+                .map(|(store_key_id, store_value)| (*store_key_id, store_value)),
+        );
 
         let result = shared_pred
             .matches(

--- a/ahnlich/db/src/engine/predicate.rs
+++ b/ahnlich/db/src/engine/predicate.rs
@@ -318,6 +318,11 @@ impl PredicateIndices {
         }
     }
 
+    #[inline]
+    pub(super) fn is_empty(&self) -> bool {
+        self.allowed_predicates.is_empty()
+    }
+
     /// returns the store key id that fulfill the predicate condition
     #[tracing::instrument(skip_all)]
     pub(super) fn matches(

--- a/ahnlich/db/src/engine/predicate.rs
+++ b/ahnlich/db/src/engine/predicate.rs
@@ -162,16 +162,6 @@ impl PredicateIndices {
         allowed_predicates.into_iter().cloned().collect()
     }
 
-    /// Removes a store key id when it's corresponding entry in the store is removed
-    #[cfg(feature = "bench-experiments")]
-    #[tracing::instrument(skip(self))]
-    pub(super) fn remove_store_keys(&self, remove_keys: &[StoreKeyId]) {
-        let pinned = self.inner.pin();
-        for (_, values) in pinned.iter() {
-            values.remove_store_keys(remove_keys);
-        }
-    }
-
     /// Removes each store key id from the predicate buckets described by its stored metadata.
     #[tracing::instrument(skip_all)]
     pub(super) fn remove_store_entries<'a>(
@@ -336,8 +326,8 @@ impl PredicateIndices {
     }
 
     #[inline]
-    pub(super) fn is_empty(&self) -> bool {
-        self.allowed_predicates.is_empty()
+    pub(super) fn has_configured_predicates(&self) -> bool {
+        !self.allowed_predicates.is_empty()
     }
 
     /// returns the store key id that fulfill the predicate condition
@@ -423,19 +413,6 @@ impl PredicateIndex {
         );
         new.add(init, parallelism_config, active_requests);
         new
-    }
-
-    /// Removes a store key id when it's corresponding entry in the store is removed
-    #[cfg(any(test, feature = "bench-experiments"))]
-    #[tracing::instrument(skip(self))]
-    fn remove_store_keys(&self, remove_keys: &[StoreKeyId]) {
-        let inner = self.0.pin();
-        for (_, values) in inner.iter() {
-            let values_pinned = values.pin();
-            for k in remove_keys {
-                values_pinned.remove(k);
-            }
-        }
     }
 
     fn remove_store_key(&self, metadata_value: &MetadataValue, store_key_id: &StoreKeyId) {
@@ -548,163 +525,6 @@ impl PredicateIndex {
                 .collect(),
 
             Predicate { kind: None } => unreachable!(),
-        }
-    }
-
-    #[cfg(feature = "bench-experiments")]
-    #[tracing::instrument(skip(self))]
-    fn matches_in_scan_bench(&self, predicate: &Predicate) -> StdHashSet<StoreKeyId> {
-        let pinned = self.0.pin();
-        match predicate {
-            Predicate {
-                kind: Some(PredicateKind::In(predicates::In { values, .. })),
-            } => pinned
-                .iter()
-                .filter(|(key, _)| values.contains(key))
-                .flat_map(|(_, value)| value.pin().iter().cloned().collect::<Vec<_>>())
-                .collect(),
-            _ => unreachable!("In scan benchmark requires an In predicate"),
-        }
-    }
-}
-
-#[cfg(feature = "bench-experiments")]
-pub mod benchmark {
-    use super::*;
-
-    pub struct PredicateInLookupBenchmark(PredicateIndex);
-
-    impl PredicateInLookupBenchmark {
-        pub fn new(entries: Vec<(MetadataValue, StoreKeyId)>) -> Self {
-            let config = super::super::store::ParallelismConfig::from_cli(1, None, usize::MAX);
-            Self(PredicateIndex::init(entries, &config, 1))
-        }
-
-        pub fn matches_control(&self, predicate: &Predicate) -> StdHashSet<StoreKeyId> {
-            self.0.matches_in_scan_bench(predicate)
-        }
-
-        pub fn matches_candidate(&self, predicate: &Predicate) -> StdHashSet<StoreKeyId> {
-            self.0.matches(predicate)
-        }
-    }
-
-    pub type PredicateIndexSnapshot =
-        HashMap<String, HashMap<MetadataValue, StdHashSet<StoreKeyId>>>;
-
-    pub struct PredicateDeletionBenchmark {
-        indices: PredicateIndices,
-        removed: Vec<(StoreKeyId, Arc<StoreValue>)>,
-        removed_keys: Vec<StoreKeyId>,
-        parallelism_config: super::super::store::ParallelismConfig,
-    }
-
-    impl PredicateDeletionBenchmark {
-        pub fn new(
-            indexed_keys: Vec<String>,
-            entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
-            removed: Vec<(StoreKeyId, Arc<StoreValue>)>,
-        ) -> Self {
-            let parallelism_config =
-                super::super::store::ParallelismConfig::from_cli(1, None, usize::MAX);
-            let indices = PredicateIndices::init(indexed_keys);
-            indices.add(entries, &parallelism_config, 1);
-            let removed_keys = removed
-                .iter()
-                .map(|(store_key_id, _)| *store_key_id)
-                .collect();
-
-            Self {
-                indices,
-                removed,
-                removed_keys,
-                parallelism_config,
-            }
-        }
-
-        pub fn remove_control(&self) {
-            self.indices.remove_store_keys(&self.removed_keys);
-        }
-
-        pub fn remove_candidate(&self) {
-            self.indices.remove_store_entries(
-                self.removed
-                    .iter()
-                    .map(|(store_key_id, store_value)| (*store_key_id, store_value.as_ref())),
-            );
-        }
-
-        pub fn restore_removed(&self) {
-            self.indices
-                .add(self.removed.clone(), &self.parallelism_config, 1);
-        }
-
-        pub fn snapshot(&self) -> PredicateIndexSnapshot {
-            let indices = self.indices.inner.pin();
-            indices
-                .iter()
-                .map(|(key, index)| {
-                    let buckets = index.0.pin();
-                    let values = buckets
-                        .iter()
-                        .map(|(value, store_key_ids)| {
-                            (value.clone(), store_key_ids.pin().iter().copied().collect())
-                        })
-                        .collect();
-                    (key.clone(), values)
-                })
-                .collect()
-        }
-    }
-
-    pub struct EmptyPredicateIngestionBenchmark {
-        indices: PredicateIndices,
-        entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
-        parallelism_config: super::super::store::ParallelismConfig,
-    }
-
-    impl EmptyPredicateIngestionBenchmark {
-        pub fn new(
-            entries: Vec<(StoreKeyId, Arc<StoreValue>)>,
-            metadata_filtering_threshold: usize,
-        ) -> Self {
-            Self {
-                indices: PredicateIndices::init(Vec::new()),
-                entries,
-                parallelism_config: super::super::store::ParallelismConfig::from_cli(
-                    rayon::current_num_threads(),
-                    None,
-                    metadata_filtering_threshold,
-                ),
-            }
-        }
-
-        pub fn run_control(&self) {
-            let predicate_insert = self
-                .entries
-                .par_iter()
-                .map(|(store_key_id, store_value)| (*store_key_id, Arc::clone(store_value)))
-                .collect();
-            self.indices
-                .add(predicate_insert, &self.parallelism_config, 1);
-        }
-
-        pub fn run_candidate(&self) {
-            if self.indices.is_empty() {
-                return;
-            }
-
-            let predicate_insert = self
-                .entries
-                .par_iter()
-                .map(|(store_key_id, store_value)| (*store_key_id, Arc::clone(store_value)))
-                .collect();
-            self.indices
-                .add(predicate_insert, &self.parallelism_config, 1);
-        }
-
-        pub fn indexed_key_count(&self) -> usize {
-            self.indices.current_predicates().len()
         }
     }
 }

--- a/ahnlich/db/src/engine/predicate.rs
+++ b/ahnlich/db/src/engine/predicate.rs
@@ -995,60 +995,25 @@ mod tests {
     #[test]
     fn test_adding_and_removing_entries_for_predicate() {
         let shared_pred = create_shared_predicate();
+        let even = MetadataValue {
+            value: Some(ahnlich_types::metadata::metadata_value::Value::RawString(
+                "Even".to_string(),
+            )),
+        };
+        let odd = MetadataValue {
+            value: Some(ahnlich_types::metadata::metadata_value::Value::RawString(
+                "Odd".to_string(),
+            )),
+        };
         assert_eq!(shared_pred.0.len(), 2);
-        assert_eq!(
-            shared_pred
-                .0
-                .pin()
-                .get(&MetadataValue {
-                    value: Some(ahnlich_types::metadata::metadata_value::Value::RawString(
-                        "Even".to_string(),
-                    )),
-                })
-                .unwrap()
-                .len(),
-            2
-        );
-        assert_eq!(
-            shared_pred
-                .0
-                .pin()
-                .get(&MetadataValue {
-                    value: Some(ahnlich_types::metadata::metadata_value::Value::RawString(
-                        "Odd".to_string(),
-                    )),
-                })
-                .unwrap()
-                .len(),
-            2
-        );
-        shared_pred.remove_store_keys(&[StoreKeyId(1), StoreKeyId(0)]);
-        assert_eq!(
-            shared_pred
-                .0
-                .pin()
-                .get(&MetadataValue {
-                    value: Some(ahnlich_types::metadata::metadata_value::Value::RawString(
-                        "Even".to_string(),
-                    )),
-                })
-                .unwrap()
-                .len(),
-            1
-        );
-        assert_eq!(
-            shared_pred
-                .0
-                .pin()
-                .get(&MetadataValue {
-                    value: Some(ahnlich_types::metadata::metadata_value::Value::RawString(
-                        "Odd".to_string(),
-                    )),
-                })
-                .unwrap()
-                .len(),
-            1
-        );
+        assert_eq!(shared_pred.0.pin().get(&even).unwrap().len(), 2);
+        assert_eq!(shared_pred.0.pin().get(&odd).unwrap().len(), 2);
+
+        shared_pred.remove_store_key(&odd, &StoreKeyId(1));
+        shared_pred.remove_store_key(&even, &StoreKeyId(0));
+
+        assert_eq!(shared_pred.0.pin().get(&even).unwrap().len(), 1);
+        assert_eq!(shared_pred.0.pin().get(&odd).unwrap().len(), 1);
     }
 
     #[test]

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -1026,17 +1026,33 @@ impl Store {
 
     #[tracing::instrument(skip_all)]
     fn delete(&self, keys: impl Iterator<Item = StoreKeyId>) -> usize {
-        let keys: Vec<StoreKeyId> = keys.collect();
         let pinned = self.id_to_value.pin();
         let removed = keys
-            .iter()
-            .flat_map(|k| pinned.remove(k))
-            .map(|(k, _)| k.clone())
+            .filter_map(|store_key_id| {
+                pinned
+                    .remove(&store_key_id)
+                    .map(|(embedding_key, store_value)| {
+                        (store_key_id, embedding_key.clone(), Arc::clone(store_value))
+                    })
+            })
             .collect::<Vec<_>>();
-        self.predicate_indices.remove_store_keys(&keys);
-        self.non_linear_indices.delete(&removed);
+        drop(pinned);
+
+        self.predicate_indices.remove_store_entries(
+            removed
+                .iter()
+                .map(|(store_key_id, _, store_value)| (*store_key_id, store_value.as_ref())),
+        );
 
         let removed_count = removed.len();
+        if !self.non_linear_indices.is_empty() {
+            let removed_embeddings = removed
+                .into_iter()
+                .map(|(_, embedding_key, _)| embedding_key)
+                .collect::<Vec<_>>();
+            self.non_linear_indices.delete(&removed_embeddings);
+        }
+
         if removed_count > 0 {
             // Mark store as needing size recalculation
             self.mark_size_dirty();
@@ -1434,6 +1450,72 @@ mod tests {
             store_key_1, store_key_2,
             "Same input should produce same hash"
         );
+    }
+
+    #[test]
+    fn targeted_predicate_deletion_removes_only_deleted_entry_memberships() {
+        let store = Store::create(
+            NonZeroUsize::new(2).unwrap(),
+            vec!["country".into(), "color".into()],
+            StdHashSet::new(),
+        );
+        let first_key = StoreKey {
+            key: vec![0.1, 0.2],
+        };
+        let second_key = StoreKey {
+            key: vec![0.3, 0.4],
+        };
+        let first_id = StoreKeyId::from(&first_key);
+        let second_id = StoreKeyId::from(&second_key);
+        let metadata_value = |value: &str| MetadataValue {
+            value: Some(ahnlich_types::metadata::metadata_value::Value::RawString(
+                value.to_string(),
+            )),
+        };
+        let store_value = |color: &str| StoreValue {
+            value: StdHashMap::from([
+                ("country".into(), metadata_value("Nigeria")),
+                ("color".into(), metadata_value(color)),
+                ("unindexed".into(), metadata_value("ignored")),
+            ]),
+        };
+
+        store
+            .add(
+                vec![
+                    (first_key, store_value("red")),
+                    (second_key, store_value("blue")),
+                ],
+                &test_parallelism_config(),
+                0,
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.delete([first_id, first_id, StoreKeyId(u64::MAX)].into_iter(),),
+            1
+        );
+
+        let matches = |key: &str, value: &str| {
+            store
+                .predicate_indices
+                .matches(
+                    &PredicateCondition {
+                        kind: Some(PredicateConditionKind::Value(Predicate {
+                            kind: Some(PredicateKind::Equals(predicates::Equals {
+                                key: key.into(),
+                                value: Some(metadata_value(value)),
+                            })),
+                        })),
+                    },
+                    &store,
+                )
+                .unwrap()
+        };
+
+        assert_eq!(matches("country", "Nigeria"), StdHashSet::from([second_id]));
+        assert!(matches("color", "red").is_empty());
+        assert_eq!(matches("color", "blue"), StdHashSet::from([second_id]));
     }
 
     fn create_store_handler_no_loom(

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -1198,11 +1198,16 @@ impl Store {
             .map(check_and_wrap)
             .collect::<Result<_, _>>()?;
 
-        // Build predicate insert list using cheap clones
-        let predicate_insert: Vec<(StoreKeyId, Arc<StoreValue>)> = res
-            .par_iter()
-            .map(|(k, _, v)| (*k, Arc::clone(v)))
-            .collect();
+        // Avoid staging predicate updates when this store has no predicate indexes.
+        let predicate_insert = if self.predicate_indices.is_empty() {
+            None
+        } else {
+            Some(
+                res.par_iter()
+                    .map(|(k, _, v)| (*k, Arc::clone(v)))
+                    .collect(),
+            )
+        };
 
         let inserted = AtomicUsize::new(0);
         let updated = AtomicUsize::new(0);
@@ -1227,8 +1232,10 @@ impl Store {
             })
             .collect();
 
-        self.predicate_indices
-            .add(predicate_insert, parallelism_config, active_requests);
+        if let Some(predicate_insert) = predicate_insert {
+            self.predicate_indices
+                .add(predicate_insert, parallelism_config, active_requests);
+        }
 
         if !self.non_linear_indices.is_empty() {
             self.non_linear_indices.insert(inserted_keys);

--- a/ahnlich/db/src/engine/store.rs
+++ b/ahnlich/db/src/engine/store.rs
@@ -1027,29 +1027,28 @@ impl Store {
     #[tracing::instrument(skip_all)]
     fn delete(&self, keys: impl Iterator<Item = StoreKeyId>) -> usize {
         let pinned = self.id_to_value.pin();
-        let removed = keys
+        let (removed_entries, removed_embeddings): (Vec<_>, Vec<_>) = keys
             .filter_map(|store_key_id| {
                 pinned
                     .remove(&store_key_id)
                     .map(|(embedding_key, store_value)| {
-                        (store_key_id, embedding_key.clone(), Arc::clone(store_value))
+                        (
+                            (store_key_id, Arc::clone(store_value)),
+                            embedding_key.clone(),
+                        )
                     })
             })
-            .collect::<Vec<_>>();
+            .unzip();
         drop(pinned);
 
         self.predicate_indices.remove_store_entries(
-            removed
+            removed_entries
                 .iter()
-                .map(|(store_key_id, _, store_value)| (*store_key_id, store_value.as_ref())),
+                .map(|(store_key_id, store_value)| (*store_key_id, store_value.as_ref())),
         );
 
-        let removed_count = removed.len();
+        let removed_count = removed_entries.len();
         if !self.non_linear_indices.is_empty() {
-            let removed_embeddings = removed
-                .into_iter()
-                .map(|(_, embedding_key, _)| embedding_key)
-                .collect::<Vec<_>>();
             self.non_linear_indices.delete(&removed_embeddings);
         }
 
@@ -1215,14 +1214,14 @@ impl Store {
             .collect::<Result<_, _>>()?;
 
         // Avoid staging predicate updates when this store has no predicate indexes.
-        let predicate_insert = if self.predicate_indices.is_empty() {
-            None
-        } else {
+        let predicate_insert = if self.predicate_indices.has_configured_predicates() {
             Some(
                 res.par_iter()
                     .map(|(k, _, v)| (*k, Arc::clone(v)))
                     .collect(),
             )
+        } else {
+            None
         };
 
         let inserted = AtomicUsize::new(0);

--- a/benchmarks/Cargo.lock
+++ b/benchmarks/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "ahnlich_client_rs"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "ahnlich_types",
  "async-trait",
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ahnlich_types"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "ahash",
  "ascii85",


### PR DESCRIPTION
## Summary

Optimizes three predicate-index paths whose work previously scaled with the complete index or input batch rather than the data relevant to the operation.

- Skip predicate staging and metadata filtering when a store has no predicate indexes.
- Resolve indexed `In` predicates through direct value-bucket lookups instead of scanning every bucket.
- Remove deleted IDs only from predicate buckets identified by removed-entry metadata.
- Keep empty predicate buckets unchanged to avoid introducing concurrent cleanup semantics.

## Implementation

### Empty-index ingestion

`Store::add` now checks whether predicate indexes are enabled before allocating the predicate staging vector, cloning each `Arc<StoreValue>`, inspecting metadata, or invoking adaptive metadata filtering.

### Direct indexed `In` lookups

Indexed `In` evaluation now performs one map lookup per requested value and combines the matching ID sets. Runtime therefore scales with requested values and matching IDs instead of total index cardinality.

### Targeted deletion

Primary-map deletion retains metadata for entries actually removed. Predicate cleanup uses that metadata to locate the exact value buckets containing each ID. Missing and duplicate requested IDs do not produce additional cleanup work. Empty buckets are deliberately retained.

## Benchmarks

### Empty-index ingestion

The candidate consistently reduced the skipped predicate phase to approximately `4.92 ns`.

| Entries | Metadata fields | Sequential control | Adaptive control |
|---:|---:|---:|---:|
| 100 | 0 | 38.135 µs | 38.285 µs |
| 1,000 | 4 | 197.05 µs | 195.46 µs |
| 10,000 | 16 | 3.7976 ms | 357.47 ms |
| 100,000 | 0 | 1.5879 ms | 944.17 µs |
| 100,000 | 16 | 41.576 ms | 3.5502 s |

These are phase-level savings. Complete `Set` performance still includes validation, key hashing, embedding preparation, and primary-map insertion.

### Direct `In` lookup

Representative results at `100,000` distinct indexed values:

| Request | Control | Candidate | Reduction |
|---|---:|---:|---:|
| 1 hit, 1 ID/value | 1.2067 ms | 91.332 ns | 99.992% |
| 4 hits, 1 ID/value | 2.9590 ms | 415.68 ns | 99.986% |
| 32 hits, 1 ID/value | 12.520 ms | 3.8421 µs | 99.969% |
| 32 misses, 1 ID/value | 6.7117 ms | 1.1719 µs | 99.983% |
| 32 mixed, 1 ID/value | 9.5686 ms | 2.3114 µs | 99.976% |
| 32 hits, 32 IDs/value | 18.389 ms | 57.236 µs | 99.689% |

Direct lookup avoids adding deduplication overhead to ordinary requests. Duplicate-heavy, low-cardinality inputs can be less favorable, but tested deduplicating and hybrid strategies degraded the more common unique-value cases.

### Targeted deletion

| Scenario | Control | Candidate | Reduction |
|---|---:|---:|---:|
| Low-cardinality sparse | 13.622 µs | 828.10 ns | 93.92% |
| High-cardinality sparse | 3.1733 s | 536.92 ns | 99.99998% |
| High-cardinality batch | 3.2365 s | 98.167 µs | 99.9970% |
| Low-cardinality dense | 148.91 ms | 8.4389 ms | 94.33% |
| Many predicate indexes | 327.68 ms | 129.19 µs | 99.9606% |
| Wide metadata | 154.06 ms | 84.621 µs | 99.9451% |

## Verification

- `cargo test -p db --lib`: 93 passed, 1 ignored
- DB production Clippy passed with warnings denied
- All three experimental benchmark targets passed Clippy
- Benchmark fixtures assert equivalent results between control and candidate implementations